### PR TITLE
feat(cli): Rich progress bar during generation

### DIFF
--- a/src/imagecli/cli.py
+++ b/src/imagecli/cli.py
@@ -82,33 +82,37 @@ def _run_generate(
     console.print(f"Prompt: [italic]{prompt[:120]}{'…' if len(prompt) > 120 else ''}[/italic]")
     console.print(f"Output → [green]{output_path}[/green]")
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        MofNCompleteColumn(),
-        TimeElapsedColumn(),
-        TimeRemainingColumn(),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Generating…", total=steps)
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            console=console,
+            transient=True,
+        ) as progress:
+            task = progress.add_task("Generating…", total=engine.effective_steps(steps))
 
-        def _step_callback(pipeline, step, timestep, callback_kwargs):  # noqa: ANN001, ANN202
-            progress.update(task, completed=step + 1)
-            return callback_kwargs
+            def _step_callback(pipeline, step, timestep, callback_kwargs):  # noqa: ANN001, ANN202
+                progress.update(task, completed=step + 1)
+                return callback_kwargs
 
-        saved = engine.generate(
-            prompt,
-            negative_prompt=negative_prompt,
-            width=width,
-            height=height,
-            steps=steps,
-            guidance=guidance,
-            seed=seed,
-            output_path=output_path,
-            callback=_step_callback,
-        )
+            saved = engine.generate(
+                prompt,
+                negative_prompt=negative_prompt,
+                width=width,
+                height=height,
+                steps=steps,
+                guidance=guidance,
+                seed=seed,
+                output_path=output_path,
+                callback=_step_callback,
+            )
+    finally:
+        if engine_instance is None:
+            engine.cleanup()
 
     console.print(f"[bold green]Saved:[/bold green] {saved}")
     try:
@@ -212,9 +216,10 @@ def batch(
     # Cache engine instances so we don't reload the model for every file.
     engine_cache: dict[str, object] = {}
 
+    n_files = len(files)
     successes, failures = 0, 0
     for i, f in enumerate(files):
-        console.rule(f"[bold]{i + 1}/{len(files)}[/bold] — {f.name}")
+        console.rule(f"[bold]{i + 1}/{n_files}[/bold] — {f.name}")
         try:
             doc = parse_prompt_file(f)
             engine_name = engine or doc.engine or cfg["engine"]

--- a/src/imagecli/cli.py
+++ b/src/imagecli/cli.py
@@ -8,6 +8,15 @@ from typing import Annotated, Optional
 
 import typer
 from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 from rich.table import Table
 
 app = typer.Typer(
@@ -73,17 +82,35 @@ def _run_generate(
     console.print(f"Prompt: [italic]{prompt[:120]}{'…' if len(prompt) > 120 else ''}[/italic]")
     console.print(f"Output → [green]{output_path}[/green]")
 
-    saved = engine.generate(
-        prompt,
-        negative_prompt=negative_prompt,
-        width=width,
-        height=height,
-        steps=steps,
-        guidance=guidance,
-        seed=seed,
-        output_path=output_path,
-    )
-    console.print(f"\n[bold green]Saved:[/bold green] {saved}")
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task("Generating…", total=steps)
+
+        def _step_callback(pipeline, step, timestep, callback_kwargs):  # noqa: ANN001, ANN202
+            progress.update(task, completed=step + 1)
+            return callback_kwargs
+
+        saved = engine.generate(
+            prompt,
+            negative_prompt=negative_prompt,
+            width=width,
+            height=height,
+            steps=steps,
+            guidance=guidance,
+            seed=seed,
+            output_path=output_path,
+            callback=_step_callback,
+        )
+
+    console.print(f"[bold green]Saved:[/bold green] {saved}")
     try:
         import torch
 
@@ -186,8 +213,8 @@ def batch(
     engine_cache: dict[str, object] = {}
 
     successes, failures = 0, 0
-    for f in files:
-        console.rule(f.name)
+    for i, f in enumerate(files):
+        console.rule(f"[bold]{i + 1}/{len(files)}[/bold] — {f.name}")
         try:
             doc = parse_prompt_file(f)
             engine_name = engine or doc.engine or cfg["engine"]

--- a/src/imagecli/engine.py
+++ b/src/imagecli/engine.py
@@ -66,6 +66,7 @@ class ImageEngine(ABC):
         guidance: float = 4.0,
         seed: int | None = None,
         output_path: Path,
+        callback: object | None = None,
         **kwargs,
     ) -> Path:
         """Generate an image and save it to output_path. Returns the saved path."""
@@ -84,6 +85,8 @@ class ImageEngine(ABC):
             guidance=guidance,
             generator=generator,
         )
+        if callback is not None:
+            pipe_kwargs["callback_on_step_end"] = callback
 
         if torch.cuda.is_available():
             torch.cuda.reset_peak_memory_stats()

--- a/src/imagecli/engine.py
+++ b/src/imagecli/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import gc
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from pathlib import Path
 
 # Minimum free system RAM (in GB) required to start loading a model.
@@ -33,6 +34,15 @@ class ImageEngine(ABC):
     @abstractmethod
     def _load(self) -> None:
         """Load the model pipeline into self._pipe. Called lazily on first generate()."""
+
+    def effective_steps(self, requested: int) -> int:
+        """Return the number of inference steps that will actually run.
+
+        The default honours the caller's requested value. Engines that hardcode
+        a fixed step count (e.g. SD3.5 Turbo) override this so that progress
+        bars and callers can display the correct total.
+        """
+        return requested
 
     def _build_pipe_kwargs(
         self,
@@ -66,7 +76,7 @@ class ImageEngine(ABC):
         guidance: float = 4.0,
         seed: int | None = None,
         output_path: Path,
-        callback: object | None = None,
+        callback: Callable[..., dict] | None = None,
         **kwargs,
     ) -> Path:
         """Generate an image and save it to output_path. Returns the saved path."""

--- a/src/imagecli/engines/sd35.py
+++ b/src/imagecli/engines/sd35.py
@@ -35,6 +35,10 @@ class SD35Engine(ImageEngine):
         self._finalize_load(self._pipe)
         print("Model ready.")
 
+    def effective_steps(self, requested: int) -> int:
+        # Turbo always runs exactly 20 steps regardless of what the caller requested.
+        return 20
+
     def _build_pipe_kwargs(
         self, prompt, *, negative_prompt, width, height, steps, guidance, generator
     ):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -150,3 +150,22 @@ def test_batch_cleanup_after_failures(mock_get_engine, mock_run, tmp_path: Path)
     assert "2 failed" in result.output
     # Cleanup must still be called even when all generations fail
     mock_engine.cleanup.assert_called_once()
+
+
+@patch("imagecli.cli._run_generate")
+@patch("imagecli.engine.get_engine")
+def test_batch_shows_file_index(mock_get_engine, mock_run, tmp_path: Path):
+    mock_engine = MagicMock()
+    mock_engine.cleanup = MagicMock()
+    mock_get_engine.return_value = mock_engine
+    mock_run.return_value = Path("/fake/out.png")
+
+    _make_md(tmp_path / "a.md")
+    _make_md(tmp_path / "b.md")
+    _make_md(tmp_path / "c.md")
+
+    result = runner.invoke(app, ["batch", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "1/3" in result.output
+    assert "2/3" in result.output
+    assert "3/3" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,7 @@ def test_run_generate_passes_callback_to_engine(tmp_path: Path):
     mock_engine.name = "flux2-klein"
     mock_engine.description = "test engine"
     mock_engine.generate.return_value = tmp_path / "out.png"
+    mock_engine.effective_steps.return_value = 20  # must be int for Rich progress bar
 
     with (
         patch("imagecli.engine.get_engine", return_value=mock_engine),
@@ -249,24 +250,5 @@ def test_run_generate_passes_callback_to_engine(tmp_path: Path):
     assert "callback" in call_kwargs
     assert call_kwargs["callback"] is not None
 
-
-@patch("imagecli.cli._run_generate")
-@patch("imagecli.engine.get_engine")
-def test_batch_shows_file_index(mock_get_engine, mock_run, tmp_path: Path):
-    mock_engine = MagicMock()
-    mock_engine.cleanup = MagicMock()
-    mock_get_engine.return_value = mock_engine
-    mock_run.return_value = Path("/fake/out.png")
-
-    for name in ("a.md", "b.md", "c.md"):
-        (tmp_path / name).write_text(
-            "---\nengine: flux2-klein\nwidth: 512\nheight: 512\nsteps: 4\n"
-            "guidance: 0.0\n---\n\ntest prompt\n"
-        )
-
-    result = runner.invoke(app, ["batch", str(tmp_path)])
-    assert result.exit_code == 0
-    # Each file rule should include its 1-based index / total
-    assert "1/3" in result.output
-    assert "2/3" in result.output
-    assert "3/3" in result.output
+    # Assert: cleanup() was called once (engine_instance is None → single-image path).
+    mock_engine.cleanup.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,3 +213,60 @@ def test_generate_shows_peak_vram(tmp_path: Path):
     assert result.exit_code == 0
     assert "Peak VRAM reserved" in result.output
     assert "8.50 GB" in result.output
+
+
+# ── progress bar ─────────────────────────────────────────────────────────────
+
+
+def test_run_generate_passes_callback_to_engine(tmp_path: Path):
+    # Arrange: mock at the engine level so _run_generate runs its full body.
+    mock_engine = MagicMock()
+    mock_engine.name = "flux2-klein"
+    mock_engine.description = "test engine"
+    mock_engine.generate.return_value = tmp_path / "out.png"
+
+    with (
+        patch("imagecli.engine.get_engine", return_value=mock_engine),
+        patch("imagecli.engine.preflight_check"),
+    ):
+        from imagecli.cli import _run_generate
+
+        _run_generate(
+            "a test prompt",
+            "",
+            "flux2-klein",
+            512,
+            512,
+            20,
+            4.0,
+            None,
+            "png",
+            tmp_path / "out.png",
+        )
+
+    # Assert: engine.generate was called with a non-None callback kwarg.
+    call_kwargs = mock_engine.generate.call_args.kwargs
+    assert "callback" in call_kwargs
+    assert call_kwargs["callback"] is not None
+
+
+@patch("imagecli.cli._run_generate")
+@patch("imagecli.engine.get_engine")
+def test_batch_shows_file_index(mock_get_engine, mock_run, tmp_path: Path):
+    mock_engine = MagicMock()
+    mock_engine.cleanup = MagicMock()
+    mock_get_engine.return_value = mock_engine
+    mock_run.return_value = Path("/fake/out.png")
+
+    for name in ("a.md", "b.md", "c.md"):
+        (tmp_path / name).write_text(
+            "---\nengine: flux2-klein\nwidth: 512\nheight: 512\nsteps: 4\n"
+            "guidance: 0.0\n---\n\ntest prompt\n"
+        )
+
+    result = runner.invoke(app, ["batch", str(tmp_path)])
+    assert result.exit_code == 0
+    # Each file rule should include its 1-based index / total
+    assert "1/3" in result.output
+    assert "2/3" in result.output
+    assert "3/3" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,6 +199,7 @@ def test_generate_shows_peak_vram(tmp_path: Path):
     mock_engine.name = "flux2-klein"
     mock_engine.description = "test engine"
     mock_engine.generate.return_value = fake_img
+    mock_engine.effective_steps.return_value = 20  # must be int for Rich progress bar
 
     with (
         patch("imagecli.engine.get_engine", return_value=mock_engine),

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -146,3 +147,49 @@ def test_preflight_no_cuda():
         # Act / Assert
         with pytest.raises(InsufficientResourcesError, match="No CUDA GPU detected"):
             preflight_check(engine)
+
+
+def test_generate_passes_callback_to_pipe(tmp_path: Path):
+    # Arrange: pre-load _pipe so _load() is skipped; inject callback.
+    engine = get_engine("flux2-klein")
+    mock_image = MagicMock()
+    mock_pipe = MagicMock(return_value=MagicMock(images=[mock_image]))
+    engine._pipe = mock_pipe
+
+    callback = MagicMock(return_value={})
+    out = tmp_path / "out.png"
+
+    with (
+        patch("torch.Generator") as mock_gen,
+        patch("torch.inference_mode") as mock_ctx,
+    ):
+        mock_ctx.return_value.__enter__ = MagicMock(return_value=None)
+        mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+        mock_gen.return_value.manual_seed.return_value = MagicMock()
+        engine.generate("test prompt", output_path=out, callback=callback)
+
+    # Assert: callback_on_step_end was forwarded to the pipeline
+    call_kwargs = mock_pipe.call_args[1]
+    assert call_kwargs.get("callback_on_step_end") is callback
+
+
+def test_generate_no_callback_omits_kwarg(tmp_path: Path):
+    # Arrange: no callback → callback_on_step_end must NOT appear in pipe kwargs.
+    engine = get_engine("flux2-klein")
+    mock_image = MagicMock()
+    mock_pipe = MagicMock(return_value=MagicMock(images=[mock_image]))
+    engine._pipe = mock_pipe
+
+    out = tmp_path / "out.png"
+
+    with (
+        patch("torch.Generator") as mock_gen,
+        patch("torch.inference_mode") as mock_ctx,
+    ):
+        mock_ctx.return_value.__enter__ = MagicMock(return_value=None)
+        mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+        mock_gen.return_value.manual_seed.return_value = MagicMock()
+        engine.generate("test prompt", output_path=out)
+
+    call_kwargs = mock_pipe.call_args[1]
+    assert "callback_on_step_end" not in call_kwargs

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -192,4 +192,11 @@ def test_generate_no_callback_omits_kwarg(tmp_path: Path):
         engine.generate("test prompt", output_path=out)
 
     call_kwargs = mock_pipe.call_args[1]
-    assert "callback_on_step_end" not in call_kwargs
+    assert set(call_kwargs.keys()) == {
+        "prompt",
+        "width",
+        "height",
+        "num_inference_steps",
+        "guidance_scale",
+        "generator",
+    }


### PR DESCRIPTION
## Summary
- Hook diffusers `callback_on_step_end` to a Rich `Progress` bar in `_run_generate()`, showing spinner, step count (X/N), elapsed time, and ETA during inference
- Batch mode rule now displays `1/N`, `2/N`, ... so users see overall file progress at a glance

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #9: feat: Rich progress bar during generation | Open |
| Implementation | 1 commit on `feat/9-rich-progress-bar` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new) | Passed |

## Test Plan
- [ ] `imagecli generate "a cat in space"` — progress bar with step counter appears during inference, disappears on completion (transient)
- [ ] `imagecli batch images/prompts_in/` — each file section header shows `1/N — filename.md`
- [ ] `imagecli generate "..." -e sd35` — bar shows 20 steps (SD3.5 hardcodes 20)
- [ ] Progress bar updates correctly at each denoising step (not just once at the end)

Closes #9

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`