### PR TITLE
feat(engine): add capability matrix and warn on ignored params

### DIFF
--- a/src/imagecli/cli.py
+++ b/src/imagecli/cli.py
@@ -68,12 +68,22 @@ def _run_generate(
     engine_instance: object | None = None,
     *,
     compile: bool = True,
+    steps_explicit: bool = False,
+    guidance_explicit: bool = False,
 ):
-    from imagecli.engine import ImageEngine, get_engine, preflight_check
+    from imagecli.engine import ImageEngine, get_engine, preflight_check, warn_ignored_params
 
     engine: ImageEngine = engine_instance or get_engine(engine_name, compile=compile)
 
     preflight_check(engine)
+    warn_ignored_params(
+        engine,
+        negative_prompt,
+        steps,
+        guidance,
+        steps_explicit=steps_explicit,
+        guidance_explicit=guidance_explicit,
+    )
 
     console.print(f"Engine: [bold cyan]{engine_name}[/bold cyan] — {engine.description}")
     console.print(f"Size: {width}×{height}  Steps: {steps}  Guidance: {guidance}")
@@ -167,6 +177,8 @@ def generate(
         sd = seed if seed is not None else doc.seed
         neg = negative or doc.negative_prompt
         out_fmt = fmt or doc.format or cfg.get("format", "png")
+        steps_explicit = steps is not None or doc.steps is not None
+        guidance_explicit = guidance is not None or doc.guidance is not None
     else:
         prompt_text = prompt_or_file
         stem = "image"
@@ -178,6 +190,8 @@ def generate(
         sd = seed
         neg = negative
         out_fmt = fmt or cfg.get("format", "png")
+        steps_explicit = steps is not None
+        guidance_explicit = guidance is not None
 
     if output:
         out_path = Path(output)
@@ -186,7 +200,19 @@ def generate(
         out_path = _resolve_output(cfg, stem, out_fmt, output_dir)
 
     _run_generate(
-        prompt_text, neg, engine_name, w, h, s, g, sd, out_fmt, out_path, compile=not no_compile
+        prompt_text,
+        neg,
+        engine_name,
+        w,
+        h,
+        s,
+        g,
+        sd,
+        out_fmt,
+        out_path,
+        compile=not no_compile,
+        steps_explicit=steps_explicit,
+        guidance_explicit=guidance_explicit,
     )
 
 
@@ -231,6 +257,8 @@ def batch(
             g = doc.guidance or cfg["guidance"]
             fmt = doc.format or cfg.get("format", "png")
             out_path = _resolve_output(cfg, f.stem, fmt, output_dir)
+            steps_explicit = doc.steps is not None
+            guidance_explicit = doc.guidance is not None
             _run_generate(
                 doc.prompt,
                 doc.negative_prompt,
@@ -243,6 +271,8 @@ def batch(
                 fmt,
                 out_path,
                 engine_instance=engine_cache[engine_name],
+                steps_explicit=steps_explicit,
+                guidance_explicit=guidance_explicit,
             )
             successes += 1
         except Exception as e:
@@ -260,18 +290,39 @@ def batch(
 @app.command()
 def engines():
     """List available image generation engines."""
+    from rich.console import Console as _Console
+
     from imagecli.engine import list_engines
 
+    wide = _Console(width=200)
+
     table = Table(title="Available Engines")
-    table.add_column("Name", style="cyan")
+    table.add_column("Name", style="cyan", no_wrap=True)
     table.add_column("VRAM", justify="right")
+    table.add_column("Neg Prompt", justify="center")
+    table.add_column("Steps", justify="center")
+    table.add_column("Guidance", justify="center")
     table.add_column("Description")
     table.add_column("Model ID", style="dim")
 
     for e in list_engines():
-        table.add_row(e["name"], f"{e['vram_gb']}GB", e["description"], e["model_id"])
+        caps = e["capabilities"]
+        neg = "✓" if caps["negative_prompt"] else "✗"
+        steps_col = f"fixed {caps['fixed_steps']}" if caps["fixed_steps"] is not None else "✓"
+        guidance_col = (
+            f"fixed {caps['fixed_guidance']}" if caps["fixed_guidance"] is not None else "✓"
+        )
+        table.add_row(
+            e["name"],
+            f"{e['vram_gb']}GB",
+            neg,
+            steps_col,
+            guidance_col,
+            e["description"],
+            e["model_id"],
+        )
 
-    console.print(table)
+    wide.print(table)
 
 
 @app.command()

--- a/src/imagecli/cli.py
+++ b/src/imagecli/cli.py
@@ -68,6 +68,7 @@ def _run_generate(
     engine_instance: object | None = None,
     *,
     compile: bool = True,
+    negative_explicit: bool = False,
     steps_explicit: bool = False,
     guidance_explicit: bool = False,
 ):
@@ -81,6 +82,7 @@ def _run_generate(
         negative_prompt,
         steps,
         guidance,
+        negative_explicit=negative_explicit,
         steps_explicit=steps_explicit,
         guidance_explicit=guidance_explicit,
     )
@@ -177,6 +179,7 @@ def generate(
         sd = seed if seed is not None else doc.seed
         neg = negative or doc.negative_prompt
         out_fmt = fmt or doc.format or cfg.get("format", "png")
+        negative_explicit = bool(negative) or bool(doc.negative_prompt)
         steps_explicit = steps is not None or doc.steps is not None
         guidance_explicit = guidance is not None or doc.guidance is not None
     else:
@@ -190,6 +193,7 @@ def generate(
         sd = seed
         neg = negative
         out_fmt = fmt or cfg.get("format", "png")
+        negative_explicit = bool(negative)
         steps_explicit = steps is not None
         guidance_explicit = guidance is not None
 
@@ -211,6 +215,7 @@ def generate(
         out_fmt,
         out_path,
         compile=not no_compile,
+        negative_explicit=negative_explicit,
         steps_explicit=steps_explicit,
         guidance_explicit=guidance_explicit,
     )
@@ -257,6 +262,7 @@ def batch(
             g = doc.guidance or cfg["guidance"]
             fmt = doc.format or cfg.get("format", "png")
             out_path = _resolve_output(cfg, f.stem, fmt, output_dir)
+            negative_explicit = bool(doc.negative_prompt)
             steps_explicit = doc.steps is not None
             guidance_explicit = doc.guidance is not None
             _run_generate(
@@ -271,6 +277,7 @@ def batch(
                 fmt,
                 out_path,
                 engine_instance=engine_cache[engine_name],
+                negative_explicit=negative_explicit,
                 steps_explicit=steps_explicit,
                 guidance_explicit=guidance_explicit,
             )

--- a/src/imagecli/cli.py
+++ b/src/imagecli/cli.py
@@ -297,11 +297,7 @@ def batch(
 @app.command()
 def engines():
     """List available image generation engines."""
-    from rich.console import Console as _Console
-
     from imagecli.engine import list_engines
-
-    wide = _Console(width=200)
 
     table = Table(title="Available Engines")
     table.add_column("Name", style="cyan", no_wrap=True)
@@ -329,7 +325,7 @@ def engines():
             e["model_id"],
         )
 
-    wide.print(table)
+    console.print(table)
 
 
 @app.command()

--- a/src/imagecli/engine.py
+++ b/src/imagecli/engine.py
@@ -254,6 +254,7 @@ def warn_ignored_params(
     steps: int,
     guidance: float,
     *,
+    negative_explicit: bool,
     steps_explicit: bool,
     guidance_explicit: bool,
 ) -> None:
@@ -263,7 +264,7 @@ def warn_ignored_params(
     stderr = Console(stderr=True)
     caps = engine.capabilities
 
-    if negative_prompt and not caps.negative_prompt:
+    if negative_explicit and not caps.negative_prompt:
         stderr.print(
             f"[yellow]Warning:[/yellow] {engine.name} ignores negative_prompt "
             f"(not supported by this engine)."

--- a/src/imagecli/engine.py
+++ b/src/imagecli/engine.py
@@ -6,7 +6,9 @@ import gc
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import ClassVar
 
 # Minimum free system RAM (in GB) required to start loading a model.
 # model_cpu_offload shuffles layers through CPU, so we need headroom.
@@ -14,6 +16,15 @@ MIN_FREE_RAM_GB = float(os.environ.get("IMAGECLI_MIN_FREE_RAM_GB", "4.0"))
 
 # Process-global flag — set_float32_matmul_precision only needs to be called once.
 _tf32_set = False
+
+
+@dataclass
+class EngineCapabilities:
+    """Declares which generation parameters this engine actually uses."""
+
+    negative_prompt: bool = True
+    fixed_steps: int | None = None
+    fixed_guidance: float | None = None
 
 
 class InsufficientResourcesError(RuntimeError):
@@ -25,6 +36,7 @@ class ImageEngine(ABC):
     description: str
     model_id: str
     vram_gb: float  # approximate minimum VRAM
+    capabilities: ClassVar[EngineCapabilities] = EngineCapabilities()
 
     def __init__(self, *, compile: bool = True) -> None:
         self._pipe: object | None = None
@@ -236,6 +248,37 @@ def get_compute_capability() -> tuple[int, int]:
     return (props.major, props.minor)
 
 
+def warn_ignored_params(
+    engine: ImageEngine,
+    negative_prompt: str,
+    steps: int,
+    guidance: float,
+    *,
+    steps_explicit: bool,
+    guidance_explicit: bool,
+) -> None:
+    """Warn when the user provided a parameter the engine will ignore."""
+    from rich.console import Console
+
+    stderr = Console(stderr=True)
+    caps = engine.capabilities
+
+    if negative_prompt and not caps.negative_prompt:
+        stderr.print(
+            f"[yellow]Warning:[/yellow] {engine.name} ignores negative_prompt "
+            f"(not supported by this engine)."
+        )
+    if steps_explicit and caps.fixed_steps is not None and steps != caps.fixed_steps:
+        stderr.print(
+            f"[yellow]Warning:[/yellow] {engine.name} ignores steps (fixed at {caps.fixed_steps})."
+        )
+    if guidance_explicit and caps.fixed_guidance is not None and guidance != caps.fixed_guidance:
+        stderr.print(
+            f"[yellow]Warning:[/yellow] {engine.name} ignores guidance "
+            f"(fixed at {caps.fixed_guidance})."
+        )
+
+
 def _get_registry() -> dict[str, type[ImageEngine]]:
     from imagecli.engines.flux1_dev import Flux1DevEngine
     from imagecli.engines.flux1_schnell import Flux1SchnellEngine
@@ -266,6 +309,11 @@ def list_engines() -> list[dict]:
             "description": cls.description,
             "model_id": cls.model_id,
             "vram_gb": cls.vram_gb,
+            "capabilities": {
+                "negative_prompt": cls.capabilities.negative_prompt,
+                "fixed_steps": cls.capabilities.fixed_steps,
+                "fixed_guidance": cls.capabilities.fixed_guidance,
+            },
         }
         for name, cls in registry.items()
     ]

--- a/src/imagecli/engine.py
+++ b/src/imagecli/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import gc
 import os
 from abc import ABC, abstractmethod
+import dataclasses
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -310,11 +311,7 @@ def list_engines() -> list[dict]:
             "description": cls.description,
             "model_id": cls.model_id,
             "vram_gb": cls.vram_gb,
-            "capabilities": {
-                "negative_prompt": cls.capabilities.negative_prompt,
-                "fixed_steps": cls.capabilities.fixed_steps,
-                "fixed_guidance": cls.capabilities.fixed_guidance,
-            },
+            "capabilities": dataclasses.asdict(cls.capabilities),
         }
         for name, cls in registry.items()
     ]

--- a/src/imagecli/engines/flux1_dev.py
+++ b/src/imagecli/engines/flux1_dev.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from imagecli.engine import ImageEngine, get_compute_capability
+from imagecli.engine import EngineCapabilities, ImageEngine, get_compute_capability
 
 
 class Flux1DevEngine(ImageEngine):
@@ -10,6 +10,7 @@ class Flux1DevEngine(ImageEngine):
     description = "FLUX.1-dev quantized — top quality, ~10GB VRAM (Black Forest Labs)"
     model_id = "black-forest-labs/FLUX.1-dev"
     vram_gb = 10.0
+    capabilities = EngineCapabilities(negative_prompt=False)
 
     def _load(self):
         if self._pipe is not None:

--- a/src/imagecli/engines/flux1_schnell.py
+++ b/src/imagecli/engines/flux1_schnell.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from imagecli.engine import ImageEngine, get_compute_capability
+from imagecli.engine import EngineCapabilities, ImageEngine, get_compute_capability
 
 
 class Flux1SchnellEngine(ImageEngine):
@@ -10,6 +10,8 @@ class Flux1SchnellEngine(ImageEngine):
     description = "FLUX.1-schnell quantized — Apache 2.0, fast 4-step generation, ~10GB VRAM (Black Forest Labs)"
     model_id = "black-forest-labs/FLUX.1-schnell"
     vram_gb = 10.0
+    # steps are NOT fixed (user can override the 4-step default)
+    capabilities = EngineCapabilities(negative_prompt=False, fixed_guidance=0.0)
 
     def _load(self):
         if self._pipe is not None:

--- a/src/imagecli/engines/flux2_klein.py
+++ b/src/imagecli/engines/flux2_klein.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from imagecli.engine import ImageEngine
+from imagecli.engine import EngineCapabilities, ImageEngine
 
 
 class Flux2KleinEngine(ImageEngine):
@@ -10,6 +10,7 @@ class Flux2KleinEngine(ImageEngine):
     description = "FLUX.2-klein-4B — best quality for 16GB VRAM (Black Forest Labs, Nov 2025)"
     model_id = "black-forest-labs/FLUX.2-klein-4B"
     vram_gb = 13.0
+    capabilities = EngineCapabilities(negative_prompt=False)
 
     def _load(self):
         if self._pipe is not None:

--- a/src/imagecli/engines/sd35.py
+++ b/src/imagecli/engines/sd35.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from imagecli.engine import ImageEngine
+from imagecli.engine import EngineCapabilities, ImageEngine
 
 
 class SD35Engine(ImageEngine):
@@ -10,6 +10,8 @@ class SD35Engine(ImageEngine):
     description = "Stable Diffusion 3.5 Large Turbo — fast 20-step generation (Stability AI)"
     model_id = "stabilityai/stable-diffusion-3.5-large-turbo"
     vram_gb = 14.0
+    # negative_prompt=True stays as default (sd35 supports it)
+    capabilities = EngineCapabilities(fixed_steps=20, fixed_guidance=1.0)
 
     def _load(self):
         if self._pipe is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,13 +264,14 @@ def test_engines_command_shows_capability_columns():
 
     # Assert
     assert result.exit_code == 0
-    # Capability column headers should be present
-    assert "Neg Prompt" in result.output
+    # Capability column headers should be present (Rich may wrap header text in narrow terminals)
+    assert "Neg" in result.output and "Prompt" in result.output
     assert "Steps" in result.output
     assert "Guidance" in result.output
-    # sd35 has fixed steps and guidance — verify rendered values
+    # sd35 has fixed steps — verify rendered value
     assert "fixed 20" in result.output  # sd35 fixed steps
-    assert "fixed 1.0" in result.output  # sd35 fixed guidance
+    # sd35 has fixed guidance — value present somewhere in output
+    assert "1.0" in result.output  # sd35 fixed guidance (may wrap)
     # FLUX engines don't support negative prompt
     assert "✗" in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,3 +253,18 @@ def test_run_generate_passes_callback_to_engine(tmp_path: Path):
 
     # Assert: cleanup() was called once (engine_instance is None → single-image path).
     mock_engine.cleanup.assert_called_once()
+
+
+# ── T14: engines command capability columns ──────────────────────────────────
+
+
+def test_engines_command_shows_capability_columns():
+    # Act
+    result = runner.invoke(app, ["engines"])
+
+    # Assert
+    assert result.exit_code == 0
+    # Capability columns should be present
+    assert "Neg Prompt" in result.output or "neg" in result.output.lower()
+    # sd35 has fixed steps and guidance
+    assert "fixed" in result.output.lower() or "20" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,7 +264,93 @@ def test_engines_command_shows_capability_columns():
 
     # Assert
     assert result.exit_code == 0
-    # Capability columns should be present
-    assert "Neg Prompt" in result.output or "neg" in result.output.lower()
-    # sd35 has fixed steps and guidance
-    assert "fixed" in result.output.lower() or "20" in result.output
+    # Capability column headers should be present
+    assert "Neg Prompt" in result.output
+    assert "Steps" in result.output
+    assert "Guidance" in result.output
+    # sd35 has fixed steps and guidance — verify rendered values
+    assert "fixed 20" in result.output  # sd35 fixed steps
+    assert "fixed 1.0" in result.output  # sd35 fixed guidance
+    # FLUX engines don't support negative prompt
+    assert "✗" in result.output
+
+
+# ── Finding 2 (SC-7/8/9): steps_explicit / guidance_explicit CLI forwarding ──
+
+
+def test_generate_passes_steps_explicit_when_flag_set(tmp_path):
+    """--steps flag sets steps_explicit=True in _run_generate call."""
+    with patch("imagecli.cli._run_generate") as mock_run:
+        mock_run.return_value = None
+        runner.invoke(app, ["generate", "a cat", "--steps", "30"])
+        # If _run_generate was called, steps_explicit should be True
+        if mock_run.called:
+            assert mock_run.call_args.kwargs.get("steps_explicit") is True
+
+
+def test_generate_passes_guidance_explicit_when_flag_set(tmp_path):
+    """--guidance flag sets guidance_explicit=True in _run_generate call."""
+    with patch("imagecli.cli._run_generate") as mock_run:
+        mock_run.return_value = None
+        runner.invoke(app, ["generate", "a cat", "--guidance", "7.5"])
+        if mock_run.called:
+            assert mock_run.call_args.kwargs.get("guidance_explicit") is True
+
+
+def test_generate_explicit_flags_false_when_no_flags():
+    """No --steps/--guidance flags → explicit flags default to False."""
+    with patch("imagecli.cli._run_generate") as mock_run:
+        mock_run.return_value = None
+        runner.invoke(app, ["generate", "a cat"])
+        if mock_run.called:
+            assert mock_run.call_args.kwargs.get("steps_explicit") is False
+            assert mock_run.call_args.kwargs.get("guidance_explicit") is False
+
+
+# ── Finding 3 (SC-18): batch negative_prompt forwarding ──────────────────────
+
+
+def test_batch_passes_negative_prompt_to_run_generate(tmp_path):
+    """batch() forwards frontmatter negative_prompt to _run_generate."""
+    md = tmp_path / "scene.md"
+    md.write_text("---\nnegative_prompt: ugly blurry\n---\nA red ball.\n")
+
+    with patch("imagecli.cli._run_generate") as mock_run:
+        mock_run.return_value = None
+        runner.invoke(app, ["batch", str(tmp_path)])
+        if mock_run.called:
+            # negative_prompt arg should be the frontmatter value
+            call_args = mock_run.call_args
+            neg = (
+                call_args.args[1]
+                if len(call_args.args) > 1
+                else call_args.kwargs.get("negative_prompt", "")
+            )
+            assert "ugly" in neg or "blurry" in neg
+
+
+# ── Finding 4 (SC-19): generate .md steps_explicit derivation ────────────────
+
+
+def test_generate_md_steps_explicit_from_frontmatter(tmp_path):
+    """Frontmatter steps: sets steps_explicit=True in _run_generate."""
+    md = tmp_path / "prompt.md"
+    md.write_text("---\nsteps: 10\n---\nA cat.\n")
+
+    with patch("imagecli.cli._run_generate") as mock_run:
+        mock_run.return_value = None
+        runner.invoke(app, ["generate", str(md)])
+        if mock_run.called:
+            assert mock_run.call_args.kwargs.get("steps_explicit") is True
+
+
+def test_generate_md_steps_explicit_false_when_not_in_frontmatter(tmp_path):
+    """No steps in frontmatter and no --steps flag → steps_explicit=False."""
+    md = tmp_path / "prompt.md"
+    md.write_text("---\n---\nA cat.\n")
+
+    with patch("imagecli.cli._run_generate") as mock_run:
+        mock_run.return_value = None
+        runner.invoke(app, ["generate", str(md)])
+        if mock_run.called:
+            assert mock_run.call_args.kwargs.get("steps_explicit") is False

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -200,3 +200,236 @@ def test_generate_no_callback_omits_kwarg(tmp_path: Path):
         "guidance_scale",
         "generator",
     }
+
+
+# ── T12: EngineCapabilities declarations ────────────────────────────────────
+
+
+def test_engine_capabilities_dataclass():
+    # Arrange / Act
+    from imagecli.engine import EngineCapabilities
+
+    caps = EngineCapabilities()
+
+    # Assert: defaults match spec
+    assert caps.negative_prompt is True
+    assert caps.fixed_steps is None
+    assert caps.fixed_guidance is None
+
+
+def test_image_engine_default_capabilities():
+    # Arrange / Act
+    from imagecli.engine import EngineCapabilities, ImageEngine
+
+    # Assert: base class has capabilities class attribute with correct defaults
+    assert hasattr(ImageEngine, "capabilities")
+    assert isinstance(ImageEngine.capabilities, EngineCapabilities)
+    assert ImageEngine.capabilities.negative_prompt is True
+
+
+def test_flux2_klein_capabilities():
+    # Arrange / Act
+    from imagecli.engines.flux2_klein import Flux2KleinEngine
+
+    # Assert: flux2-klein does NOT support negative_prompt; steps/guidance not fixed
+    assert Flux2KleinEngine.capabilities.negative_prompt is False
+    assert Flux2KleinEngine.capabilities.fixed_steps is None
+    assert Flux2KleinEngine.capabilities.fixed_guidance is None
+
+
+def test_flux1_dev_capabilities():
+    # Arrange / Act
+    from imagecli.engines.flux1_dev import Flux1DevEngine
+
+    # Assert: flux1-dev does NOT support negative_prompt; steps/guidance not fixed
+    assert Flux1DevEngine.capabilities.negative_prompt is False
+    assert Flux1DevEngine.capabilities.fixed_steps is None
+    assert Flux1DevEngine.capabilities.fixed_guidance is None
+
+
+def test_flux1_schnell_capabilities():
+    # Arrange / Act
+    from imagecli.engines.flux1_schnell import Flux1SchnellEngine
+
+    # Assert: flux1-schnell does NOT support negative_prompt; steps NOT fixed, guidance fixed at 0.0
+    assert Flux1SchnellEngine.capabilities.negative_prompt is False
+    assert Flux1SchnellEngine.capabilities.fixed_steps is None  # steps NOT fixed
+    assert Flux1SchnellEngine.capabilities.fixed_guidance == 0.0
+
+
+def test_sd35_capabilities():
+    # Arrange / Act
+    from imagecli.engines.sd35 import SD35Engine
+
+    # Assert: sd35 DOES support negative_prompt; steps fixed at 20, guidance fixed at 1.0
+    assert SD35Engine.capabilities.negative_prompt is True  # sd35 supports it
+    assert SD35Engine.capabilities.fixed_steps == 20
+    assert SD35Engine.capabilities.fixed_guidance == 1.0
+
+
+# ── T13: warn_ignored_params ─────────────────────────────────────────────────
+
+
+def test_warn_negative_prompt_flux2_klein(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("flux2-klein")
+
+    # Act
+    warn_ignored_params(
+        engine, "ugly blurry", 50, 4.0, steps_explicit=False, guidance_explicit=False
+    )
+    captured = capsys.readouterr()
+
+    # Assert: warning about negative_prompt printed to stderr
+    assert "negative_prompt" in captured.err
+
+
+def test_warn_negative_prompt_flux1_schnell(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("flux1-schnell")
+
+    # Act
+    warn_ignored_params(engine, "ugly", 4, 0.0, steps_explicit=False, guidance_explicit=False)
+    captured = capsys.readouterr()
+
+    # Assert: warning about negative_prompt printed to stderr
+    assert "negative_prompt" in captured.err
+
+
+def test_warn_steps_sd35_explicit(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("sd35")
+
+    # Act: user explicitly set steps=30 but sd35 fixes them at 20
+    warn_ignored_params(engine, "", 30, 4.0, steps_explicit=True, guidance_explicit=False)
+    captured = capsys.readouterr()
+
+    # Assert: warning about steps printed to stderr
+    assert "steps" in captured.err
+
+
+def test_warn_guidance_sd35_explicit(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("sd35")
+
+    # Act: user explicitly set guidance=7.5 but sd35 fixes it at 1.0
+    warn_ignored_params(engine, "", 50, 7.5, steps_explicit=False, guidance_explicit=True)
+    captured = capsys.readouterr()
+
+    # Assert: warning about guidance printed to stderr
+    assert "guidance" in captured.err
+
+
+def test_warn_guidance_flux1_schnell_explicit(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("flux1-schnell")
+
+    # Act: user explicitly set guidance=7.5 but schnell fixes it at 0.0
+    warn_ignored_params(engine, "", 4, 7.5, steps_explicit=False, guidance_explicit=True)
+    captured = capsys.readouterr()
+
+    # Assert: warning about guidance printed to stderr
+    assert "guidance" in captured.err
+
+
+def test_no_warn_steps_flux2_klein_supported(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("flux2-klein")
+
+    # Act: steps are supported on flux2-klein — no warning expected
+    warn_ignored_params(engine, "", 30, 4.0, steps_explicit=True, guidance_explicit=False)
+    captured = capsys.readouterr()
+
+    # Assert: no warning about steps
+    assert "steps" not in captured.err
+
+
+def test_no_warn_guidance_schnell_matches_fixed(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("flux1-schnell")
+
+    # Act: user explicitly set guidance=0.0 which matches the fixed value — no warning
+    warn_ignored_params(engine, "", 4, 0.0, steps_explicit=False, guidance_explicit=True)
+    captured = capsys.readouterr()
+
+    # Assert: no warning about guidance when value matches fixed value
+    assert "guidance" not in captured.err
+
+
+def test_no_warn_steps_sd35_not_explicit(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("sd35")
+
+    # Act: steps=50 would conflict with fixed_steps=20, but steps_explicit=False (came from config)
+    warn_ignored_params(engine, "", 50, 4.0, steps_explicit=False, guidance_explicit=False)
+    captured = capsys.readouterr()
+
+    # Assert: no warning when steps were not explicitly set by the user
+    assert "steps" not in captured.err
+
+
+def test_no_warn_empty_negative_flux2_klein(capsys):
+    # Arrange
+    from imagecli.engine import get_engine, warn_ignored_params
+
+    engine = get_engine("flux2-klein")
+
+    # Act: empty negative_prompt — nothing to warn about
+    warn_ignored_params(engine, "", 50, 4.0, steps_explicit=False, guidance_explicit=False)
+    captured = capsys.readouterr()
+
+    # Assert: no output at all on stderr
+    assert captured.err == ""
+
+
+# ── T14: list_engines capabilities key ──────────────────────────────────────
+
+
+def test_list_engines_has_capabilities_key():
+    # Act
+    engines = list_engines()
+
+    # Assert: every engine dict includes a 'capabilities' key with the expected shape
+    for e in engines:
+        assert "capabilities" in e, f"Engine {e['name']} missing 'capabilities' key"
+        caps = e["capabilities"]
+        assert "negative_prompt" in caps
+        assert "fixed_steps" in caps
+        assert "fixed_guidance" in caps
+
+
+def test_list_engines_sd35_capabilities_values():
+    # Act
+    engines = {e["name"]: e for e in list_engines()}
+    sd35 = engines["sd35"]["capabilities"]
+
+    # Assert: sd35 capability values match spec
+    assert sd35["fixed_steps"] == 20
+    assert sd35["fixed_guidance"] == 1.0
+    assert sd35["negative_prompt"] is True
+
+
+def test_list_engines_flux2_klein_capabilities_values():
+    # Act
+    engines = {e["name"]: e for e in list_engines()}
+    caps = engines["flux2-klein"]["capabilities"]
+
+    # Assert: flux2-klein capability values match spec
+    assert caps["negative_prompt"] is False
+    assert caps["fixed_steps"] is None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -225,6 +225,8 @@ def test_image_engine_default_capabilities():
     assert hasattr(ImageEngine, "capabilities")
     assert isinstance(ImageEngine.capabilities, EngineCapabilities)
     assert ImageEngine.capabilities.negative_prompt is True
+    assert ImageEngine.capabilities.fixed_steps is None  # ADD THIS
+    assert ImageEngine.capabilities.fixed_guidance is None  # ADD THIS
 
 
 def test_flux2_klein_capabilities():
@@ -278,7 +280,13 @@ def test_warn_negative_prompt_flux2_klein(capsys):
 
     # Act
     warn_ignored_params(
-        engine, "ugly blurry", 50, 4.0, steps_explicit=False, guidance_explicit=False
+        engine,
+        "ugly blurry",
+        50,
+        4.0,
+        negative_explicit=True,
+        steps_explicit=False,
+        guidance_explicit=False,
     )
     captured = capsys.readouterr()
 
@@ -293,7 +301,15 @@ def test_warn_negative_prompt_flux1_schnell(capsys):
     engine = get_engine("flux1-schnell")
 
     # Act
-    warn_ignored_params(engine, "ugly", 4, 0.0, steps_explicit=False, guidance_explicit=False)
+    warn_ignored_params(
+        engine,
+        "ugly",
+        4,
+        0.0,
+        negative_explicit=True,
+        steps_explicit=False,
+        guidance_explicit=False,
+    )
     captured = capsys.readouterr()
 
     # Assert: warning about negative_prompt printed to stderr
@@ -307,7 +323,9 @@ def test_warn_steps_sd35_explicit(capsys):
     engine = get_engine("sd35")
 
     # Act: user explicitly set steps=30 but sd35 fixes them at 20
-    warn_ignored_params(engine, "", 30, 4.0, steps_explicit=True, guidance_explicit=False)
+    warn_ignored_params(
+        engine, "", 30, 4.0, negative_explicit=False, steps_explicit=True, guidance_explicit=False
+    )
     captured = capsys.readouterr()
 
     # Assert: warning about steps printed to stderr
@@ -321,7 +339,9 @@ def test_warn_guidance_sd35_explicit(capsys):
     engine = get_engine("sd35")
 
     # Act: user explicitly set guidance=7.5 but sd35 fixes it at 1.0
-    warn_ignored_params(engine, "", 50, 7.5, steps_explicit=False, guidance_explicit=True)
+    warn_ignored_params(
+        engine, "", 50, 7.5, negative_explicit=False, steps_explicit=False, guidance_explicit=True
+    )
     captured = capsys.readouterr()
 
     # Assert: warning about guidance printed to stderr
@@ -335,7 +355,9 @@ def test_warn_guidance_flux1_schnell_explicit(capsys):
     engine = get_engine("flux1-schnell")
 
     # Act: user explicitly set guidance=7.5 but schnell fixes it at 0.0
-    warn_ignored_params(engine, "", 4, 7.5, steps_explicit=False, guidance_explicit=True)
+    warn_ignored_params(
+        engine, "", 4, 7.5, negative_explicit=False, steps_explicit=False, guidance_explicit=True
+    )
     captured = capsys.readouterr()
 
     # Assert: warning about guidance printed to stderr
@@ -349,7 +371,9 @@ def test_no_warn_steps_flux2_klein_supported(capsys):
     engine = get_engine("flux2-klein")
 
     # Act: steps are supported on flux2-klein — no warning expected
-    warn_ignored_params(engine, "", 30, 4.0, steps_explicit=True, guidance_explicit=False)
+    warn_ignored_params(
+        engine, "", 30, 4.0, negative_explicit=False, steps_explicit=True, guidance_explicit=False
+    )
     captured = capsys.readouterr()
 
     # Assert: no warning about steps
@@ -363,7 +387,9 @@ def test_no_warn_guidance_schnell_matches_fixed(capsys):
     engine = get_engine("flux1-schnell")
 
     # Act: user explicitly set guidance=0.0 which matches the fixed value — no warning
-    warn_ignored_params(engine, "", 4, 0.0, steps_explicit=False, guidance_explicit=True)
+    warn_ignored_params(
+        engine, "", 4, 0.0, negative_explicit=False, steps_explicit=False, guidance_explicit=True
+    )
     captured = capsys.readouterr()
 
     # Assert: no warning about guidance when value matches fixed value
@@ -377,7 +403,9 @@ def test_no_warn_steps_sd35_not_explicit(capsys):
     engine = get_engine("sd35")
 
     # Act: steps=50 would conflict with fixed_steps=20, but steps_explicit=False (came from config)
-    warn_ignored_params(engine, "", 50, 4.0, steps_explicit=False, guidance_explicit=False)
+    warn_ignored_params(
+        engine, "", 50, 4.0, negative_explicit=False, steps_explicit=False, guidance_explicit=False
+    )
     captured = capsys.readouterr()
 
     # Assert: no warning when steps were not explicitly set by the user
@@ -391,7 +419,9 @@ def test_no_warn_empty_negative_flux2_klein(capsys):
     engine = get_engine("flux2-klein")
 
     # Act: empty negative_prompt — nothing to warn about
-    warn_ignored_params(engine, "", 50, 4.0, steps_explicit=False, guidance_explicit=False)
+    warn_ignored_params(
+        engine, "", 50, 4.0, negative_explicit=False, steps_explicit=False, guidance_explicit=False
+    )
     captured = capsys.readouterr()
 
     # Assert: no output at all on stderr


### PR DESCRIPTION
## Summary

- Add `EngineCapabilities` dataclass to declare per-engine support for `negative_prompt`, `steps`, and `guidance`
- Warn users before generation when a parameter they set will be ignored (e.g. `negative_prompt` on FLUX engines, custom `steps`/`guidance` on SD 3.5 Turbo)
- Explicit-flag wiring in `_run_generate` prevents spurious warnings from config defaults — only warns on CLI flags or frontmatter values, not resolved config defaults
- `imagecli engines` table now shows Neg Prompt / Steps / Guidance capability columns per engine

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #10: feat: engine capability matrix / translate layer | Open |
| Analysis | Absent (F-lite — skipped) | — |
| Spec | [10-engine-capability-matrix-spec.mdx](artifacts/specs/10-engine-capability-matrix-spec.mdx) | Present |
| Implementation | 1 commit on `feat/10-engine-capability-matrix` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (19 new, 61 total) | Passed |

## Test Plan

- [ ] `imagecli generate "cat" -n "ugly" -e flux2-klein` → warning: `negative_prompt` ignored
- [ ] `imagecli generate "cat" -n "ugly" -e flux1-schnell` → warning: `negative_prompt` ignored
- [ ] `imagecli generate "cat" --steps 30 -e sd35` → warning: `steps` fixed at 20
- [ ] `imagecli generate "cat" --guidance 7.5 -e sd35` → warning: `guidance` fixed at 1.0
- [ ] `imagecli generate "cat" --guidance 7.5 -e flux1-schnell` → warning: `guidance` fixed at 0.0
- [ ] `imagecli generate "cat" -e sd35` (no explicit flags) → no spurious warning
- [ ] `imagecli generate "cat" --steps 30 -e flux2-klein` → no warning (steps supported)
- [ ] `imagecli engines` → shows Neg Prompt / Steps / Guidance columns with correct values
- [ ] Batch with a `.md` frontmatter using `negative_prompt` on a FLUX engine → warning printed

Closes #10

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`