### PR TITLE
chore(pivotal): spec SC-6 atol drift + integration sentinel test

### DIFF
--- a/artifacts/specs/31-pivotal-tuning-embeddings-spec.mdx
+++ b/artifacts/specs/31-pivotal-tuning-embeddings-spec.mdx
@@ -249,14 +249,17 @@ CLI[--trigger,--embedding]
 - [ ] **SC-4** `emb_params` present in LoRA file + no trigger resolved (no `--trigger`, no frontmatter `trigger:`, no unambiguous sibling file) → raises an error whose message includes the substring `--trigger` and names the silent-drop failure mode
 - [ ] **SC-5a** `apply_pivotal_to_pipe` calls `tokenizer.add_tokens(placeholder_tokens)` and asserts the return value equals `N = emb_params.shape[0]`; raises if fewer were added
 - [ ] **SC-5b** `apply_pivotal_to_pipe` is independent of `unload_lora_weights` — calling `pipe.unload_lora_weights()` AFTER `apply_pivotal_to_pipe` leaves `tokenizer.added_tokens_encoder[trigger]` and `embed_tokens.weight[placeholder_ids[0]]` unchanged (unit test with a mock `unload_lora_weights` that is a no-op for TE/tokenizer)
-- [ ] **SC-6** Deterministic round-trip assertion at load time (inside `apply_pivotal_to_pipe`, run on every pivotal load):
+- [x] **SC-6** Deterministic round-trip check at load time (inside `apply_pivotal_to_pipe`, run on every pivotal load). **Must not be `assert`** — `assert` is stripped under `python -O` and would defeat the silent-drop prevention design goal. Use explicit `raise RuntimeError`:
   ```python
-  assert tokenizer.convert_tokens_to_ids(trigger) == placeholder_ids[0]
+  trigger_id = tokenizer.convert_tokens_to_ids(trigger)
+  if trigger_id != placeholder_ids[0]:
+      raise RuntimeError(...)
   te_rows = te.get_input_embeddings().weight[placeholder_ids].detach().float().cpu()
   src    = vectors.detach().float().cpu()
-  assert torch.allclose(te_rows, src, atol=1e-2), "pivotal round-trip failed"
+  if not torch.allclose(te_rows, src, atol=5e-2):
+      raise RuntimeError("pivotal round-trip: vector mismatch, max abs diff ...")
   ```
-  `atol=1e-2` is the correct bound: `emb_params` is typically stored as fp32 by ai-toolkit, the TE is bf16, and fp32→bf16→fp32 round-trip introduces error up to ~7.8e-3 (one bf16 ULP at magnitude 1). `1e-6` would always fail; `1e-2` still catches a completely wrong row (random-init) while tolerating the expected precision loss
+  **`atol=5e-2`** (revised from the original `atol=1e-2` during implementation). The original bound was derived for magnitude-1 values (`bf16 ULP ≈ 2^-8 ≈ 3.9e-3` at magnitude 1, so ~7.8e-3 round-trip worst case). However, bf16 ULP **scales with value magnitude** (`ULP ≈ |value| * 2^-8`), so at the ~3–4 magnitudes seen in `torch.randn`-sized tensors the per-value round-trip error can reach ~1.5e-2. `1e-2` reliably failed in testing; `5e-2` holds under the worst case while still catching a genuinely wrong row (random-init vs trained differs by ~1.0 in magnitude — a 20x safety margin). Real trained embeddings are typically smaller in magnitude (~0.02–1.0) with correspondingly tighter round-trip error, but the check must hold under the looser worst case.
 - [ ] **SC-7** Pivotal inference works on `flux2-klein` (quanto FP8) end-to-end: engine loads, SC-6 assertion passes, `imagecli generate "lyraface cat" --lora … --trigger lyraface -e flux2-klein` writes a valid PNG, peak VRAM within ±0.2 GB of the baseline LoRA path
 - [ ] **SC-8** Pivotal inference works on `flux2-klein-fp4` (NVFP4) end-to-end: engine loads, SC-6 assertion passes after `_runtime_quantize_transformer_to_nvfp4`, `imagecli generate … -e flux2-klein-fp4` writes a valid PNG
 - [ ] **SC-9** Visual A/B: same pivotal LoRA + same seed + prompt containing the bare trigger, run WITH the fix vs WITHOUT (git-checkout a pre-fix commit for the "without" half). Generated images visibly differ at the face. Artifact directory `~/.roxabi/forge/lyra/brand/V24-pivotal-verification/` contains:

--- a/tests/test_pivotal.py
+++ b/tests/test_pivotal.py
@@ -525,3 +525,70 @@ def test_load_pivotal_embedding_standalone_missing_file(tmp_path: Path):
             trigger="lyraface",
             embedding_path=ghost,
         )
+
+
+# ── Integration sentinel: Flux2KleinPipeline class structure ──────────────
+
+
+def test_flux2_klein_pipeline_class_structure_sentinel():
+    """Catch diffusers attribute renames that would silently break the pivotal
+    engine hooks. imageCLI's apply_pivotal_to_pipe + _patch_encode_prompt rely
+    on specific attribute names on a Flux2KleinPipeline instance:
+
+      - pipe.tokenizer            (Qwen2Tokenizer)
+      - pipe.text_encoder         (Qwen3Model)
+      - pipe.encode_prompt(...)   (instance method, monkey-patched)
+
+    If a future diffusers upgrade renames any of these (e.g. tokenizer →
+    tokenizer_2, text_encoder → t5_encoder, encode_prompt → _encode_text),
+    the MagicMock-based unit tests above would still pass but production
+    would crash at load time. This sentinel checks the real Flux2KleinPipeline
+    class structure without loading any weights, so it runs cheaply in CI and
+    fails fast on attribute drift.
+    """
+    import inspect
+
+    from diffusers import Flux2KleinPipeline
+
+    # Constructor parameters — these are the registered modules that the
+    # pipeline expects at instantiation. imageCLI's engine hooks access
+    # `self._pipe.tokenizer` and `self._pipe.text_encoder` after from_pretrained
+    # returns, so both names must be present here.
+    init_params = set(inspect.signature(Flux2KleinPipeline.__init__).parameters)
+    assert "tokenizer" in init_params, (
+        f"Flux2KleinPipeline.__init__ no longer accepts 'tokenizer' — "
+        f"pivotal hooks will break. Got params: {init_params}"
+    )
+    assert "text_encoder" in init_params, (
+        f"Flux2KleinPipeline.__init__ no longer accepts 'text_encoder' — "
+        f"pivotal hooks will break. Got params: {init_params}"
+    )
+    assert "transformer" in init_params, (
+        f"Flux2KleinPipeline.__init__ no longer accepts 'transformer' — "
+        f"engine load paths will break. Got params: {init_params}"
+    )
+
+    # encode_prompt must be a method on the pipeline class — _patch_encode_prompt
+    # replaces it at the instance level, so the class must expose it as the
+    # original callable.
+    assert hasattr(Flux2KleinPipeline, "encode_prompt"), (
+        "Flux2KleinPipeline no longer has an 'encode_prompt' method — "
+        "_patch_encode_prompt monkey-patch target is missing."
+    )
+    assert callable(getattr(Flux2KleinPipeline, "encode_prompt", None)), (
+        "Flux2KleinPipeline.encode_prompt is not callable."
+    )
+
+    # Must inherit LoRA loading (used by the engines before pivotal hooks fire)
+    # and be a DiffusionPipeline subclass (MRO sanity).
+    from diffusers.loaders.lora_pipeline import Flux2LoraLoaderMixin
+    from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+
+    assert issubclass(Flux2KleinPipeline, DiffusionPipeline), (
+        "Flux2KleinPipeline no longer inherits DiffusionPipeline — "
+        "pipeline class resolution may have shifted."
+    )
+    assert issubclass(Flux2KleinPipeline, Flux2LoraLoaderMixin), (
+        "Flux2KleinPipeline no longer inherits Flux2LoraLoaderMixin — "
+        "the pre-pivotal LoRA fuse path may break."
+    )


### PR DESCRIPTION
## Summary

Two small review follow-ups from the #32 code-review that weren't worth blocking the original merge:

1. **Update spec SC-6 atol** — implementation uses `atol=5e-2`, spec still said `atol=1e-2`. Corrected with the bf16-ULP-scales-with-magnitude rationale (already present as an inline code comment in \`pivotal.py\`). Also fixed the spec's example from \`assert\` to explicit \`raise RuntimeError\` per the implemented behavior. Marked SC-6 as done.

2. **Add integration sentinel test for \`Flux2KleinPipeline\`** — catches future diffusers upgrades that could silently rename the attributes pivotal hooks depend on (\`tokenizer\`, \`text_encoder\`, \`encode_prompt\`, transformer constructor param). Uses \`inspect.signature\` + class MRO checks; loads no weights; runs in <1s. The existing MagicMock-based unit tests can't catch attribute renames because the mock provides the attributes itself — this sentinel checks the real class structure.

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Intent | Follow-ups from #32 review — no new issue (small, tightly-scoped) | — |
| Implementation | 1 commit on \`chore/31-followups\` | Complete |
| Verification | Lint ✅  Tests ✅ (29/29 pivotal, 115/115 total) | Passed |

## Test Plan

- [x] \`uv run pytest tests/test_pivotal.py -v\` — 29/29 passing including the new sentinel
- [x] \`uv run ruff check .\` — clean
- [x] Sentinel loads zero weights (verified via test runtime <1s)

## What this does NOT include

The third follow-up from the review — "file a follow-up issue for multi-LoRA with independent embeddings" — is a separate action, filed as a new GitHub issue rather than this PR.

Refs: #31, #32

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/dev\` follow-up