### PR TITLE
feat(engine): add pulid-flux2-klein-fp4 NVFP4-quantized engine

### DIFF
--- a/src/imagecli/engine.py
+++ b/src/imagecli/engine.py
@@ -449,6 +449,7 @@ def _get_registry() -> dict[str, type[ImageEngine]]:
     from imagecli.engines.flux2_klein_fp8 import Flux2KleinFP8Engine
     from imagecli.engines.pulid_flux1_dev import PuLIDFlux1DevEngine
     from imagecli.engines.pulid_flux2_klein import PuLIDFlux2KleinEngine
+    from imagecli.engines.pulid_flux2_klein_fp4 import PuLIDFlux2KleinFP4Engine
     from imagecli.engines.sd35 import SD35Engine
 
     return {
@@ -456,6 +457,7 @@ def _get_registry() -> dict[str, type[ImageEngine]]:
         "flux2-klein-fp8": Flux2KleinFP8Engine,
         "flux2-klein-fp4": Flux2KleinFP4Engine,
         "pulid-flux2-klein": PuLIDFlux2KleinEngine,
+        "pulid-flux2-klein-fp4": PuLIDFlux2KleinFP4Engine,
         "flux1-dev": Flux1DevEngine,
         "pulid-flux1-dev": PuLIDFlux1DevEngine,
         "flux1-schnell": Flux1SchnellEngine,

--- a/src/imagecli/engines/pulid_flux2_klein.py
+++ b/src/imagecli/engines/pulid_flux2_klein.py
@@ -305,6 +305,65 @@ def _patch_flux(
     return unpatch
 
 
+# ── shared identity extraction ────────────────────────────────────────────────
+
+
+def _extract_id_tokens(
+    insightface: object,
+    eva_clip: object,
+    pulid: _PuLIDFlux2,
+    face_image_path: str,
+) -> torch.Tensor:
+    """Extract PuLID identity tokens from a face reference image.
+
+    Shared by PuLIDFlux2KleinEngine and PuLIDFlux2KleinFP4Engine so that any
+    bug fix applies to both engines automatically.
+    """
+    from PIL import Image
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    img = np.array(Image.open(face_image_path).convert("RGB"))
+    faces = insightface.get(img)  # type: ignore[union-attr]
+    if not faces:
+        raise RuntimeError(f"No face detected in reference image: {face_image_path}")
+
+    face = max(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))
+
+    id_embed = torch.from_numpy(face.embedding).unsqueeze(0).to(device, dtype=dtype)
+    id_embed = F.normalize(id_embed, dim=-1)
+
+    x1, y1, x2, y2 = face.bbox.astype(int)
+    margin = int(max(x2 - x1, y2 - y1) * 0.2)
+    x1, y1 = max(0, x1 - margin), max(0, y1 - margin)
+    x2, y2 = min(img.shape[1], x2 + margin), min(img.shape[0], y2 + margin)
+
+    face_t = (
+        torch.from_numpy(img[y1:y2, x1:x2].astype(np.float32) / 255.0)
+        .permute(2, 0, 1)
+        .unsqueeze(0)
+        .to(device)
+    )
+    face_t = F.interpolate(face_t, size=(336, 336), mode="bilinear", align_corners=False)
+    mean = torch.tensor([0.48145466, 0.4578275, 0.40821073], device=device).view(1, 3, 1, 1)
+    std = torch.tensor([0.26862954, 0.26130258, 0.27577711], device=device).view(1, 3, 1, 1)
+    face_t = (face_t - mean) / std
+
+    with torch.no_grad():
+        clip_out = eva_clip(face_t.float())  # type: ignore[union-attr]
+        if isinstance(clip_out, (list, tuple)):
+            clip_out = clip_out[0]
+        if clip_out.dim() == 3:
+            clip_out = clip_out[:, 0, :]
+        clip_embed = clip_out.to(device, dtype=dtype)
+
+        id_tokens = pulid.id_former(id_embed, clip_embed)
+        id_tokens = F.normalize(id_tokens, p=2, dim=-1)
+
+    return id_tokens
+
+
 # ── engine ─────────────────────────────────────────────────────────────────────
 
 
@@ -380,49 +439,7 @@ class PuLIDFlux2KleinEngine(ImageEngine):
         logger.info("PuLID engine ready.")
 
     def _extract_id_tokens(self, face_image_path: str) -> torch.Tensor:
-        from PIL import Image
-
-        device = torch.device("cuda")
-        dtype = torch.bfloat16
-
-        img = np.array(Image.open(face_image_path).convert("RGB"))
-        faces = self._insightface.get(img)  # type: ignore[union-attr]
-        if not faces:
-            raise RuntimeError(f"No face detected in reference image: {face_image_path}")
-
-        face = max(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))
-
-        id_embed = torch.from_numpy(face.embedding).unsqueeze(0).to(device, dtype=dtype)
-        id_embed = F.normalize(id_embed, dim=-1)
-
-        x1, y1, x2, y2 = face.bbox.astype(int)
-        margin = int(max(x2 - x1, y2 - y1) * 0.2)
-        x1, y1 = max(0, x1 - margin), max(0, y1 - margin)
-        x2, y2 = min(img.shape[1], x2 + margin), min(img.shape[0], y2 + margin)
-
-        face_t = (
-            torch.from_numpy(img[y1:y2, x1:x2].astype(np.float32) / 255.0)
-            .permute(2, 0, 1)
-            .unsqueeze(0)
-            .to(device)
-        )
-        face_t = F.interpolate(face_t, size=(336, 336), mode="bilinear", align_corners=False)
-        mean = torch.tensor([0.48145466, 0.4578275, 0.40821073], device=device).view(1, 3, 1, 1)
-        std = torch.tensor([0.26862954, 0.26130258, 0.27577711], device=device).view(1, 3, 1, 1)
-        face_t = (face_t - mean) / std
-
-        with torch.no_grad():
-            clip_out = self._eva_clip(face_t.float())  # type: ignore[union-attr]
-            if isinstance(clip_out, (list, tuple)):
-                clip_out = clip_out[0]
-            if clip_out.dim() == 3:
-                clip_out = clip_out[:, 0, :]
-            clip_embed = clip_out.to(device, dtype=dtype)
-
-            id_tokens = self._pulid.id_former(id_embed, clip_embed)  # type: ignore[union-attr]
-            id_tokens = F.normalize(id_tokens, p=2, dim=-1)
-
-        return id_tokens
+        return _extract_id_tokens(self._insightface, self._eva_clip, self._pulid, face_image_path)
 
     def generate(
         self,

--- a/src/imagecli/engines/pulid_flux2_klein_fp4.py
+++ b/src/imagecli/engines/pulid_flux2_klein_fp4.py
@@ -1,0 +1,245 @@
+"""FLUX.2-klein-4B + PuLID face identity lock, NVFP4-quantized — Blackwell only.
+
+Combines the NVFP4 runtime quantization path from flux2_klein_fp4 with the
+PuLID CA activation injection from pulid_flux2_klein.
+
+Load path:
+  1. Load BF16 base transformer (same repo as pulid-flux2-klein)
+  2. Runtime-quantize all nn.Linear to NVFP4 via QuantizedTensor.from_float
+     (same function as flux2-klein-fp4 LoRA path)
+  3. Place all components on GPU — no cpu_offload (NVFP4 kernels require CUDA)
+  4. Override _execution_device so the pipeline routes denoising to CUDA
+
+Generation path: identical to pulid-flux2-klein (EVA-CLIP offload → _patch_flux
+→ super().generate → unpatch → EVA-CLIP restore).
+
+Requires: sm_120+ (RTX 5070 Ti / Blackwell), CUDA 13.0+, comfy-kitchen.
+Install: uv sync --extra pulid --group fp4
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from imagecli.engine import EngineCapabilities, ImageEngine
+from imagecli.engines.pulid_flux2_klein import (
+    _INSIGHTFACE_DIR,
+    _PULID_DEFAULT,
+    _PuLIDFlux2,
+    _patch_flux,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PuLIDFlux2KleinFP4Engine(ImageEngine):
+    name = "pulid-flux2-klein-fp4"
+    description = (
+        "FLUX.2-klein-4B + PuLID face lock, NVFP4 quantized — Blackwell only "
+        "(sm_120+, ~8.5 GB). Requires face_image in frontmatter."
+    )
+    model_id = "black-forest-labs/FLUX.2-klein-4B"
+    vram_gb = 8.5
+    capabilities = EngineCapabilities(negative_prompt=False)
+
+    def __init__(self, *, compile: bool = True, **kwargs: object) -> None:
+        # torch.compile captures original forward methods — incompatible with per-generation
+        # PuLID patching. Force compile=False, same as pulid-flux2-klein.
+        # LoRA not supported; absorb kwargs to allow batch() passthrough.
+        super().__init__(compile=False, **kwargs)  # type: ignore[arg-type]
+        self._pulid: _PuLIDFlux2 | None = None
+        self._insightface: object | None = None
+        self._eva_clip: object | None = None
+
+    # ── hardware + dependency checks ──────────────────────────────────────────
+
+    def _check_requirements(self) -> None:
+        if not torch.cuda.is_available():
+            raise RuntimeError("pulid-flux2-klein-fp4 requires a CUDA GPU.")
+        sm = torch.cuda.get_device_capability()
+        if sm < (12, 0):
+            raise RuntimeError(
+                f"pulid-flux2-klein-fp4 requires Blackwell GPU (sm_120+), "
+                f"got sm_{sm[0]}{sm[1]}."
+            )
+        cuda_ver = torch.version.cuda
+        if cuda_ver and int(cuda_ver.split(".")[0]) < 13:
+            raise RuntimeError(
+                f"pulid-flux2-klein-fp4 requires CUDA 13.0+ (cu130), got {cuda_ver}."
+            )
+        try:
+            import comfy_kitchen  # noqa: F401
+        except ImportError:
+            raise RuntimeError(
+                "pulid-flux2-klein-fp4 requires comfy-kitchen. "
+                "Install: uv sync --extra pulid --group fp4"
+            )
+
+    # ── execution device override (same logic as Flux2KleinFP4Engine) ─────────
+
+    def _set_execution_device(self) -> None:
+        """Override pipeline._execution_device so all-on-GPU denoising routes to CUDA.
+
+        Without this, pipelines that skip enable_model_cpu_offload() may resolve
+        the execution device from offload hooks that don't exist and silently
+        fall back to CPU.
+        """
+        self._pipe._execution_device_override = torch.device("cuda")  # type: ignore[union-attr]
+        orig_cls = type(self._pipe)
+        if not hasattr(orig_cls, "_orig_execution_device"):
+            orig_cls._orig_execution_device = orig_cls._execution_device  # type: ignore[attr-defined]
+            orig_cls._execution_device = property(  # type: ignore[attr-defined]
+                lambda pipe: getattr(pipe, "_execution_device_override", None)
+                or orig_cls._orig_execution_device.fget(pipe)
+            )
+
+    # ── load ──────────────────────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        if self._pipe is not None:
+            return
+
+        import os
+
+        os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+        self._check_requirements()
+
+        from diffusers import Flux2KleinPipeline
+
+        from imagecli.engines.flux2_klein_fp4 import _runtime_quantize_transformer_to_nvfp4
+
+        logger.info("Loading Flux2Klein BF16 base for PuLID-FP4…")
+        self._pipe = Flux2KleinPipeline.from_pretrained(
+            self.model_id,
+            torch_dtype=torch.bfloat16,
+        )
+
+        # Quantize transformer to NVFP4 before moving other components to GPU.
+        # Transformer lands first (~2 GB), then text encoder (~4.5 GB) + VAE (~0.2 GB).
+        self._pipe.transformer.to("cuda")  # type: ignore[union-attr]
+        n_quantized = _runtime_quantize_transformer_to_nvfp4(self._pipe.transformer)  # type: ignore[union-attr]
+        logger.info("Runtime-quantized %d linear layers to NVFP4.", n_quantized)
+
+        self._pipe.text_encoder.to("cuda")  # type: ignore[union-attr]
+        self._pipe.vae.to("cuda")  # type: ignore[union-attr]
+        self._set_execution_device()
+        self._optimize_pipe(self._pipe, compile=False)
+
+        # PuLID model — same weights and path as pulid-flux2-klein
+        logger.info("Loading PuLID model from %s…", _PULID_DEFAULT)
+        self._pulid = _PuLIDFlux2.from_safetensors(_PULID_DEFAULT)
+        self._pulid.eval().to("cuda", dtype=torch.bfloat16)
+
+        logger.info("Loading InsightFace (AntelopeV2)…")
+        from insightface.app import FaceAnalysis  # type: ignore[import-untyped]
+
+        self._insightface = FaceAnalysis(
+            name="antelopev2",
+            root=str(_INSIGHTFACE_DIR),
+            providers=["CUDAExecutionProvider"],
+        )
+        self._insightface.prepare(ctx_id=0, det_size=(640, 640))  # type: ignore[union-attr]
+
+        logger.info("Loading EVA-CLIP…")
+        import open_clip  # type: ignore[import-untyped]
+
+        clip_model, _, _ = open_clip.create_model_and_transforms(
+            "EVA02-L-14-336",
+            pretrained="merged2b_s6b_b61k",
+        )
+        self._eva_clip = clip_model.visual.eval().to("cuda")
+        logger.info("PuLID-FP4 engine ready.")
+
+    # ── identity extraction (copied from PuLIDFlux2KleinEngine) ──────────────
+
+    def _extract_id_tokens(self, face_image_path: str) -> torch.Tensor:
+        from PIL import Image
+
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+
+        img = np.array(Image.open(face_image_path).convert("RGB"))
+        faces = self._insightface.get(img)  # type: ignore[union-attr]
+        if not faces:
+            raise RuntimeError(f"No face detected in reference image: {face_image_path}")
+
+        face = max(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))
+
+        id_embed = torch.from_numpy(face.embedding).unsqueeze(0).to(device, dtype=dtype)
+        id_embed = F.normalize(id_embed, dim=-1)
+
+        x1, y1, x2, y2 = face.bbox.astype(int)
+        margin = int(max(x2 - x1, y2 - y1) * 0.2)
+        x1, y1 = max(0, x1 - margin), max(0, y1 - margin)
+        x2, y2 = min(img.shape[1], x2 + margin), min(img.shape[0], y2 + margin)
+
+        face_t = (
+            torch.from_numpy(img[y1:y2, x1:x2].astype(np.float32) / 255.0)
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .to(device)
+        )
+        face_t = F.interpolate(face_t, size=(336, 336), mode="bilinear", align_corners=False)
+        mean = torch.tensor([0.48145466, 0.4578275, 0.40821073], device=device).view(1, 3, 1, 1)
+        std = torch.tensor([0.26862954, 0.26130258, 0.27577711], device=device).view(1, 3, 1, 1)
+        face_t = (face_t - mean) / std
+
+        with torch.no_grad():
+            clip_out = self._eva_clip(face_t.float())  # type: ignore[union-attr]
+            if isinstance(clip_out, (list, tuple)):
+                clip_out = clip_out[0]
+            if clip_out.dim() == 3:
+                clip_out = clip_out[:, 0, :]
+            clip_embed = clip_out.to(device, dtype=dtype)
+
+            id_tokens = self._pulid.id_former(id_embed, clip_embed)  # type: ignore[union-attr]
+            id_tokens = F.normalize(id_tokens, p=2, dim=-1)
+
+        return id_tokens
+
+    # ── generate ──────────────────────────────────────────────────────────────
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        face_image: str | None = None,
+        pulid_strength: float = 0.6,
+        output_path: Path,
+        **kwargs: object,
+    ) -> Path:
+        if not face_image:
+            raise ValueError(
+                "pulid-flux2-klein-fp4 requires 'face_image' in the prompt frontmatter.\n"
+                "Example: face_image: /path/to/reference.png"
+            )
+
+        self._load()
+        id_tokens = self._extract_id_tokens(face_image)
+
+        # EVA-CLIP is done — move to CPU to reclaim ~1 GB before denoising
+        if self._eva_clip is not None:
+            self._eva_clip.to("cpu")
+        torch.cuda.empty_cache()
+
+        unpatch = _patch_flux(self._pipe.transformer, self._pulid, id_tokens, pulid_strength)  # type: ignore[union-attr]
+        try:
+            return super().generate(prompt, output_path=output_path, **kwargs)
+        finally:
+            unpatch()
+            if self._eva_clip is not None:
+                self._eva_clip.to("cuda")
+
+    # ── cleanup ───────────────────────────────────────────────────────────────
+
+    def cleanup(self) -> None:
+        self._pulid = None
+        self._insightface = None
+        self._eva_clip = None
+        super().cleanup()

--- a/src/imagecli/engines/pulid_flux2_klein_fp4.py
+++ b/src/imagecli/engines/pulid_flux2_klein_fp4.py
@@ -22,15 +22,12 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import numpy as np
-import torch
-import torch.nn.functional as F
-
 from imagecli.engine import EngineCapabilities, ImageEngine
 from imagecli.engines.pulid_flux2_klein import (
     _INSIGHTFACE_DIR,
     _PULID_DEFAULT,
     _PuLIDFlux2,
+    _extract_id_tokens,
     _patch_flux,
 )
 
@@ -59,6 +56,8 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
     # ── hardware + dependency checks ──────────────────────────────────────────
 
     def _check_requirements(self) -> None:
+        import torch
+
         if not torch.cuda.is_available():
             raise RuntimeError("pulid-flux2-klein-fp4 requires a CUDA GPU.")
         sm = torch.cuda.get_device_capability()
@@ -85,18 +84,19 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
     def _set_execution_device(self) -> None:
         """Override pipeline._execution_device so all-on-GPU denoising routes to CUDA.
 
-        Without this, pipelines that skip enable_model_cpu_offload() may resolve
-        the execution device from offload hooks that don't exist and silently
-        fall back to CPU.
+        Creates a per-instance anonymous subclass with a fixed _execution_device
+        property so the patch is isolated to this pipeline object and is fully
+        reversed in cleanup() by restoring the original class.
         """
-        self._pipe._execution_device_override = torch.device("cuda")  # type: ignore[union-attr]
+        import torch  # noqa: F401 (torch.device used below)
+
         orig_cls = type(self._pipe)
-        if not hasattr(orig_cls, "_orig_execution_device"):
-            orig_cls._orig_execution_device = orig_cls._execution_device  # type: ignore[attr-defined]
-            orig_cls._execution_device = property(  # type: ignore[attr-defined]
-                lambda pipe: getattr(pipe, "_execution_device_override", None)
-                or orig_cls._orig_execution_device.fget(pipe)
-            )
+        patched_cls = type(
+            f"_{orig_cls.__name__}AllGPU",
+            (orig_cls,),
+            {"_execution_device": property(lambda _self: torch.device("cuda"))},
+        )
+        self._pipe.__class__ = patched_cls  # type: ignore[union-attr]
 
     # ── load ──────────────────────────────────────────────────────────────────
 
@@ -106,9 +106,15 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
 
         import os
 
+        import torch
+
         os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
 
         self._check_requirements()
+
+        from imagecli.engine import preflight_check
+
+        preflight_check(self)
 
         from diffusers import Flux2KleinPipeline
 
@@ -120,9 +126,11 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
             torch_dtype=torch.bfloat16,
         )
 
-        # Quantize transformer to NVFP4 before moving other components to GPU.
-        # Transformer lands first (~2 GB), then text encoder (~4.5 GB) + VAE (~0.2 GB).
-        self._pipe.transformer.to("cuda")  # type: ignore[union-attr]
+        # Runtime-quantize transformer to NVFP4 — weights are moved to CUDA
+        # layer-by-layer inside _runtime_quantize_transformer_to_nvfp4, so no
+        # explicit transformer.to("cuda") is needed before quantization. This
+        # avoids a ~10 GB BF16 peak that would occur if the full transformer
+        # were moved to GPU before quantization begins.
         n_quantized = _runtime_quantize_transformer_to_nvfp4(self._pipe.transformer)  # type: ignore[union-attr]
         logger.info("Runtime-quantized %d linear layers to NVFP4.", n_quantized)
 
@@ -156,53 +164,6 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
         self._eva_clip = clip_model.visual.eval().to("cuda")
         logger.info("PuLID-FP4 engine ready.")
 
-    # ── identity extraction (copied from PuLIDFlux2KleinEngine) ──────────────
-
-    def _extract_id_tokens(self, face_image_path: str) -> torch.Tensor:
-        from PIL import Image
-
-        device = torch.device("cuda")
-        dtype = torch.bfloat16
-
-        img = np.array(Image.open(face_image_path).convert("RGB"))
-        faces = self._insightface.get(img)  # type: ignore[union-attr]
-        if not faces:
-            raise RuntimeError(f"No face detected in reference image: {face_image_path}")
-
-        face = max(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))
-
-        id_embed = torch.from_numpy(face.embedding).unsqueeze(0).to(device, dtype=dtype)
-        id_embed = F.normalize(id_embed, dim=-1)
-
-        x1, y1, x2, y2 = face.bbox.astype(int)
-        margin = int(max(x2 - x1, y2 - y1) * 0.2)
-        x1, y1 = max(0, x1 - margin), max(0, y1 - margin)
-        x2, y2 = min(img.shape[1], x2 + margin), min(img.shape[0], y2 + margin)
-
-        face_t = (
-            torch.from_numpy(img[y1:y2, x1:x2].astype(np.float32) / 255.0)
-            .permute(2, 0, 1)
-            .unsqueeze(0)
-            .to(device)
-        )
-        face_t = F.interpolate(face_t, size=(336, 336), mode="bilinear", align_corners=False)
-        mean = torch.tensor([0.48145466, 0.4578275, 0.40821073], device=device).view(1, 3, 1, 1)
-        std = torch.tensor([0.26862954, 0.26130258, 0.27577711], device=device).view(1, 3, 1, 1)
-        face_t = (face_t - mean) / std
-
-        with torch.no_grad():
-            clip_out = self._eva_clip(face_t.float())  # type: ignore[union-attr]
-            if isinstance(clip_out, (list, tuple)):
-                clip_out = clip_out[0]
-            if clip_out.dim() == 3:
-                clip_out = clip_out[:, 0, :]
-            clip_embed = clip_out.to(device, dtype=dtype)
-
-            id_tokens = self._pulid.id_former(id_embed, clip_embed)  # type: ignore[union-attr]
-            id_tokens = F.normalize(id_tokens, p=2, dim=-1)
-
-        return id_tokens
-
     # ── generate ──────────────────────────────────────────────────────────────
 
     def generate(
@@ -220,8 +181,10 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
                 "Example: face_image: /path/to/reference.png"
             )
 
+        import torch
+
         self._load()
-        id_tokens = self._extract_id_tokens(face_image)
+        id_tokens = _extract_id_tokens(self._insightface, self._eva_clip, self._pulid, face_image)
 
         # EVA-CLIP is done — move to CPU to reclaim ~1 GB before denoising
         if self._eva_clip is not None:
@@ -239,6 +202,10 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
     # ── cleanup ───────────────────────────────────────────────────────────────
 
     def cleanup(self) -> None:
+        # Restore the original pipeline class before teardown so the per-instance
+        # AllGPU subclass created by _set_execution_device() doesn't leak.
+        if self._pipe is not None and type(self._pipe).__name__.endswith("AllGPU"):
+            self._pipe.__class__ = type(self._pipe).__bases__[0]
         self._pulid = None
         self._insightface = None
         self._eva_clip = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ def test_engines_command():
     assert "flux2-klein" in result.output
     assert "flux1-dev" in result.output
     assert "sd35" in result.output
+    assert "pulid-flux2-klein-fp4" in result.output
 
 
 def test_info_command_no_cuda():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -27,6 +27,11 @@ def test_registry_has_all_engines():
     assert "flux1-dev" in registry
     assert "flux1-schnell" in registry
     assert "sd35" in registry
+    assert "pulid-flux2-klein-fp4" in registry
+    assert "pulid-flux2-klein" in registry
+    assert "flux2-klein-fp4" in registry
+    assert "flux2-klein-fp8" in registry
+    assert "pulid-flux1-dev" in registry
 
 
 def test_get_engine_valid():
@@ -463,3 +468,85 @@ def test_list_engines_flux2_klein_capabilities_values():
     # Assert: flux2-klein capability values match spec
     assert caps["negative_prompt"] is False
     assert caps["fixed_steps"] is None
+
+
+# ── PuLIDFlux2KleinFP4Engine — _check_requirements() ───────────────────────
+
+
+def test_pulid_fp4_check_requirements_no_cuda():
+    """_check_requirements() raises RuntimeError when no CUDA GPU is present."""
+    from imagecli.engines.pulid_flux2_klein_fp4 import PuLIDFlux2KleinFP4Engine
+
+    engine = PuLIDFlux2KleinFP4Engine()
+
+    with (
+        patch.dict("sys.modules", {"comfy_kitchen": MagicMock()}),
+        patch("torch.cuda.is_available", return_value=False),
+    ):
+        with pytest.raises(RuntimeError, match="requires a CUDA GPU"):
+            engine._check_requirements()
+
+
+def test_pulid_fp4_check_requirements_wrong_sm():
+    """_check_requirements() raises RuntimeError when GPU is below sm_120 (Blackwell)."""
+    import torch as _torch
+    from imagecli.engines.pulid_flux2_klein_fp4 import PuLIDFlux2KleinFP4Engine
+
+    engine = PuLIDFlux2KleinFP4Engine()
+
+    with (
+        patch.dict("sys.modules", {"comfy_kitchen": MagicMock()}),
+        patch("torch.cuda.is_available", return_value=True),
+        patch("torch.cuda.get_device_capability", return_value=(8, 6)),
+        patch.object(_torch.version, "cuda", "13.0"),
+    ):
+        with pytest.raises(RuntimeError, match="sm_120"):
+            engine._check_requirements()
+
+
+def test_pulid_fp4_check_requirements_old_cuda():
+    """_check_requirements() raises RuntimeError when CUDA version is below 13."""
+    import torch as _torch
+    from imagecli.engines.pulid_flux2_klein_fp4 import PuLIDFlux2KleinFP4Engine
+
+    engine = PuLIDFlux2KleinFP4Engine()
+
+    with (
+        patch.dict("sys.modules", {"comfy_kitchen": MagicMock()}),
+        patch("torch.cuda.is_available", return_value=True),
+        patch("torch.cuda.get_device_capability", return_value=(12, 0)),
+        patch.object(_torch.version, "cuda", "12.4"),
+    ):
+        with pytest.raises(RuntimeError, match="CUDA 13.0"):
+            engine._check_requirements()
+
+
+def test_pulid_fp4_check_requirements_missing_comfy_kitchen():
+    """_check_requirements() raises RuntimeError when comfy_kitchen is not importable."""
+    import torch as _torch
+    from imagecli.engines.pulid_flux2_klein_fp4 import PuLIDFlux2KleinFP4Engine
+
+    engine = PuLIDFlux2KleinFP4Engine()
+
+    with (
+        patch.dict("sys.modules", {"comfy_kitchen": None}),
+        patch("torch.cuda.is_available", return_value=True),
+        patch("torch.cuda.get_device_capability", return_value=(12, 0)),
+        patch.object(_torch.version, "cuda", "13.0"),
+    ):
+        with pytest.raises(RuntimeError, match="comfy-kitchen"):
+            engine._check_requirements()
+
+
+# ── PuLIDFlux2KleinFP4Engine — generate() face_image guard ──────────────────
+
+
+def test_pulid_fp4_generate_requires_face_image():
+    """generate() must raise ValueError when face_image is not provided."""
+    from imagecli.engines.pulid_flux2_klein_fp4 import PuLIDFlux2KleinFP4Engine
+
+    engine = PuLIDFlux2KleinFP4Engine()
+    engine._pipe = MagicMock()  # skip _load()
+
+    with pytest.raises(ValueError, match="face_image"):
+        engine.generate("a prompt", output_path=Path("/tmp/out.png"))


### PR DESCRIPTION
## Summary
- Add `pulid-flux2-klein-fp4` engine: runtime-quantizes the FLUX.2-klein-4B transformer to NVFP4 (reusing `_runtime_quantize_transformer_to_nvfp4` from `flux2-klein-fp4`), then runs PuLID CA activation injection unchanged
- All components placed on GPU (no `enable_model_cpu_offload`); `_set_execution_device()` overrides pipeline device routing for CUDA dispatch; `torch.compile` explicitly disabled (CA patching incompatibility)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #35: feat(engine): NVFP4 + PuLID path for pulid-flux2-klein | Open |
| Analysis | — | Skipped (F-lite) |
| Spec | [35-nvfp4-pulid-flux2-klein-spec.mdx](artifacts/specs/35-nvfp4-pulid-flux2-klein-spec.mdx) | Present |
| Implementation | 1 commit on `feat/35-nvfp4-pulid-flux2-klein` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (115 passed) | Passed |

## Test Plan
- [ ] `imagecli engines` lists `pulid-flux2-klein-fp4` at 8.5 GB
- [ ] `imagecli generate <face_prompt.md> -e pulid-flux2-klein-fp4` completes without error on Blackwell GPU
- [ ] Logs emit "Runtime-quantized N linear layers to NVFP4" (N > 0)
- [ ] Peak VRAM ≤ 9.5 GB at 1024×1024 / 28 steps
- [ ] Wall-clock < 12s at 1024×1024 / 28 steps
- [ ] ArcFace cosine sim delta vs BF16 baseline ≥ −0.02 (same seed/strength/steps)
- [ ] `_check_requirements()` raises on non-Blackwell or missing comfy-kitchen

Closes #35

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`