### PR TITLE
refactor(engines): split pulid_flux1_dev.py into _pulid/ sub-package

### DIFF
--- a/src/imagecli/engines/_pulid/__init__.py
+++ b/src/imagecli/engines/_pulid/__init__.py
@@ -1,0 +1,20 @@
+"""PuLID sub-package for the FLUX.1-dev face-lock engine.
+
+Extracted from ``pulid_flux1_dev.py`` in #55 to keep the engine file under the
+300 LOC quality gate. Only the symbols re-exported here are considered public
+within ``imagecli``; helper functions in ``modules`` keep their leading
+underscore.
+"""
+
+from __future__ import annotations
+
+from .modules import IDFormer, PerceiverAttention, PerceiverAttentionCA, PuLIDFlux1
+from .patching import patch_flux1
+
+__all__ = [
+    "IDFormer",
+    "PerceiverAttention",
+    "PerceiverAttentionCA",
+    "PuLIDFlux1",
+    "patch_flux1",
+]

--- a/src/imagecli/engines/_pulid/modules.py
+++ b/src/imagecli/engines/_pulid/modules.py
@@ -1,0 +1,244 @@
+"""Inlined PuLID nn.Module definitions.
+
+These match the weights in ``pulid_flux_v0.9.1.safetensors`` exactly. The file
+stays self-contained — no imports from the external PuLID repo — so the
+safetensors state_dict loads without key rewriting.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+# Block schedule constants — match the PuLID FLUX.1 reference implementation.
+# Also consumed by ``patching.patch_flux1``.
+_DOUBLE_INTERVAL = 2
+_SINGLE_INTERVAL = 4
+_N_DOUBLE = 19
+_N_SINGLE = 38
+
+# ceil(19/2)=10, ceil(38/4)=10 -> 20 CA modules total.
+_NUM_CA = math.ceil(_N_DOUBLE / _DOUBLE_INTERVAL) + math.ceil(_N_SINGLE / _SINGLE_INTERVAL)
+
+
+def _reshape_tensor(x: torch.Tensor, heads: int) -> torch.Tensor:
+    bs, length, width = x.shape
+    x = x.view(bs, length, heads, -1)
+    x = x.transpose(1, 2)
+    return x.reshape(bs, heads, length, -1)
+
+
+class PerceiverAttention(nn.Module):
+    """Self+cross attention used inside IDFormer (query attends to context + self)."""
+
+    def __init__(self, *, dim: int, dim_head: int = 64, heads: int = 8, kv_dim: int | None = None):
+        super().__init__()
+        self.dim_head = dim_head
+        self.heads = heads
+        inner_dim = dim_head * heads
+        kv = kv_dim if kv_dim is not None else dim
+        self.norm1 = nn.LayerNorm(kv)
+        self.norm2 = nn.LayerNorm(dim)
+        self.to_q = nn.Linear(dim, inner_dim, bias=False)
+        self.to_kv = nn.Linear(kv, inner_dim * 2, bias=False)
+        self.to_out = nn.Linear(inner_dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor, latents: torch.Tensor) -> torch.Tensor:
+        x = self.norm1(x)
+        latents = self.norm2(latents)
+        b, seq_len, _ = latents.shape
+        q = self.to_q(latents)
+        kv_input = torch.cat((x, latents), dim=-2)
+        k, v = self.to_kv(kv_input).chunk(2, dim=-1)
+        q, k, v = (_reshape_tensor(t, self.heads) for t in (q, k, v))
+        scale = 1 / math.sqrt(math.sqrt(self.dim_head))
+        weight = (q * scale) @ (k * scale).transpose(-2, -1)
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        out = weight @ v
+        out = out.permute(0, 2, 1, 3).reshape(b, seq_len, -1)
+        return self.to_out(out)
+
+
+def _FeedForward(dim: int, mult: int = 4) -> nn.Sequential:
+    inner = int(dim * mult)
+    return nn.Sequential(
+        nn.LayerNorm(dim),
+        nn.Linear(dim, inner, bias=False),
+        nn.GELU(),
+        nn.Linear(inner, dim, bias=False),
+    )
+
+
+class IDFormer(nn.Module):
+    """Perceiver-resampler identity encoder.
+
+    Matches IDFormer(dim=1024, depth=10, dim_head=64, heads=16,
+                     num_id_token=5, num_queries=32, output_dim=2048).
+
+    Input:
+        x  — id_cond  (B, 1280)  = concat[insightface_512, eva_cls_768]
+        y  — id_vit_hidden  list[5] of (B, N, 1024)  multi-scale EVA features
+    Output:
+        (B, 32, 2048)  id_tokens consumed by PerceiverAttentionCA
+    """
+
+    def __init__(
+        self,
+        dim: int = 1024,
+        depth: int = 10,
+        dim_head: int = 64,
+        heads: int = 16,
+        num_id_token: int = 5,
+        num_queries: int = 32,
+        output_dim: int = 2048,
+        ff_mult: int = 4,
+    ):
+        super().__init__()
+        self.num_id_token = num_id_token
+        self.dim = dim
+        self.num_queries = num_queries
+        assert depth % 5 == 0
+        self.depth = depth // 5
+        scale = dim**-0.5
+
+        self.latents = nn.Parameter(torch.randn(1, num_queries, dim) * scale)
+        self.proj_out = nn.Parameter(scale * torch.randn(dim, output_dim))
+
+        self.layers = nn.ModuleList([])
+        for _ in range(depth):
+            self.layers.append(
+                nn.ModuleList(
+                    [
+                        PerceiverAttention(dim=dim, dim_head=dim_head, heads=heads),
+                        _FeedForward(dim=dim, mult=ff_mult),
+                    ]
+                )
+            )
+
+        for i in range(5):
+            setattr(
+                self,
+                f"mapping_{i}",
+                nn.Sequential(
+                    nn.Linear(1024, 1024),
+                    nn.LayerNorm(1024),
+                    nn.LeakyReLU(),
+                    nn.Linear(1024, 1024),
+                    nn.LayerNorm(1024),
+                    nn.LeakyReLU(),
+                    nn.Linear(1024, dim),
+                ),
+            )
+
+        self.id_embedding_mapping = nn.Sequential(
+            nn.Linear(1280, 1024),
+            nn.LayerNorm(1024),
+            nn.LeakyReLU(),
+            nn.Linear(1024, 1024),
+            nn.LayerNorm(1024),
+            nn.LeakyReLU(),
+            nn.Linear(1024, dim * num_id_token),
+        )
+
+    def forward(self, x: torch.Tensor, y: list[torch.Tensor]) -> torch.Tensor:
+        latents = self.latents.repeat(x.size(0), 1, 1)
+        num_duotu = x.shape[1] if x.ndim == 3 else 1
+        x = self.id_embedding_mapping(x)
+        x = x.reshape(-1, self.num_id_token * num_duotu, self.dim)
+        latents = torch.cat((latents, x), dim=1)
+        for i in range(5):
+            vit_feature = getattr(self, f"mapping_{i}")(y[i])
+            ctx_feature = torch.cat((x, vit_feature), dim=1)
+            for attn, ff in self.layers[i * self.depth : (i + 1) * self.depth]:
+                latents = attn(ctx_feature, latents) + latents
+                latents = ff(latents) + latents
+        latents = latents[:, : self.num_queries]
+        latents = latents @ self.proj_out
+        return latents
+
+
+class PerceiverAttentionCA(nn.Module):
+    """Cross-attention module that injects id_tokens into image hidden states.
+
+    Matches PerceiverAttentionCA(dim=3072, dim_head=128, heads=16, kv_dim=2048).
+
+    forward(x=id_tokens, latents=hidden_states) → correction (same shape as hidden_states)
+
+    Note: the weight file uses the BFL argument order: forward(id, img) which maps to
+    forward(x=id_tokens, latents=img_hidden_states). We preserve that convention.
+    """
+
+    def __init__(
+        self, *, dim: int = 3072, dim_head: int = 128, heads: int = 16, kv_dim: int = 2048
+    ):
+        super().__init__()
+        self.dim_head = dim_head
+        self.heads = heads
+        inner_dim = dim_head * heads  # 2048
+
+        self.norm1 = nn.LayerNorm(kv_dim)  # norm for id_tokens (kv_dim=2048)
+        self.norm2 = nn.LayerNorm(dim)  # norm for hidden_states (dim=3072)
+
+        self.to_q = nn.Linear(dim, inner_dim, bias=False)  # hidden -> queries
+        self.to_kv = nn.Linear(kv_dim, inner_dim * 2, bias=False)  # id -> k,v
+        self.to_out = nn.Linear(inner_dim, dim, bias=False)  # -> dim=3072
+
+    def forward(self, id_tokens: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            id_tokens:     (B, 32, 2048)  output of IDFormer
+            hidden_states: (B, N, 3072)   image stream from transformer block
+        Returns:
+            correction:    (B, N, 3072)   to be added (scaled) to hidden_states
+        """
+        dtype = self.norm2.weight.dtype
+        id_tokens = id_tokens.to(dtype)
+        hidden_states = hidden_states.to(dtype)
+
+        id_n = self.norm1(id_tokens)  # (B, 32, 2048)
+        hs_n = self.norm2(hidden_states)  # (B, N, 3072)
+
+        b, seq_len, _ = hidden_states.shape
+
+        q = self.to_q(hs_n)  # (B, N, 2048)
+        k, v = self.to_kv(id_n).chunk(2, dim=-1)  # each (B, 32, 2048)
+
+        q, k, v = (_reshape_tensor(t, self.heads) for t in (q, k, v))
+        # q: (B, heads, N, dim_head)  k,v: (B, heads, 32, dim_head)
+
+        scale = 1 / math.sqrt(math.sqrt(self.dim_head))
+        weight = (q * scale) @ (k * scale).transpose(-2, -1)  # (B, heads, N, 32)
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        out = weight @ v  # (B, heads, N, dim_head)
+
+        out = out.permute(0, 2, 1, 3).reshape(b, seq_len, -1)  # (B, N, 2048)
+        return self.to_out(out)  # (B, N, 3072)
+
+
+class PuLIDFlux1(nn.Module):
+    """Container for PuLID FLUX.1 weights — IDFormer + 20 CA modules."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pulid_encoder = IDFormer()
+        self.pulid_ca = nn.ModuleList([PerceiverAttentionCA() for _ in range(_NUM_CA)])
+
+    @classmethod
+    def from_safetensors(cls, path: Path) -> "PuLIDFlux1":
+        from safetensors.torch import load_file
+
+        state = load_file(str(path), device="cpu")
+        # Keys use 'pulid_encoder.*' and 'pulid_ca.*' prefixes — map directly
+        model = cls()
+        missing, unexpected = model.load_state_dict(state, strict=False)
+        if missing:
+            logger.warning("PuLID weights: missing keys: %s", missing[:5])
+        if unexpected:
+            logger.warning("PuLID weights: unexpected keys: %s", unexpected[:5])
+        return model

--- a/src/imagecli/engines/_pulid/patching.py
+++ b/src/imagecli/engines/_pulid/patching.py
@@ -1,0 +1,121 @@
+"""FLUX.1-dev transformer monkey-patching for PuLID identity injection.
+
+``patch_flux1`` rewrites the ``forward`` methods on selected double and single
+transformer blocks to add a PuLID CA correction to the image stream. The
+patching is per-generation and reversible — the returned ``unpatch`` callable
+restores the original forwards. Incompatible with ``torch.compile`` since
+``compile`` captures the original forward method bodies.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .modules import _DOUBLE_INTERVAL, _SINGLE_INTERVAL, PuLIDFlux1
+
+
+def patch_flux1(
+    transformer: object,
+    pulid: PuLIDFlux1,
+    id_tokens: torch.Tensor,
+    strength: float,
+) -> object:
+    """Monkey-patch FLUX.1-dev diffusers transformer blocks to inject PuLID identity.
+
+    Double blocks (FluxTransformerBlock):
+        - Every _DOUBLE_INTERVAL-th block (0, 2, 4, ...) gets a correction on
+          hidden_states (image stream).
+        - forward signature: (hidden_states, encoder_hidden_states, temb,
+                               image_rotary_emb, joint_attention_kwargs)
+          returns: (encoder_hidden_states, hidden_states)
+
+    Single blocks (FluxSingleTransformerBlock):
+        - Every _SINGLE_INTERVAL-th block (0, 4, 8, ...) gets a correction on
+          hidden_states (image stream, AFTER txt split).
+        - forward signature: same as double block
+          returns: (encoder_hidden_states, hidden_states)
+          Internally concatenates txt+img, processes them, then splits back.
+          The returned hidden_states is already the image-only portion.
+
+    Returns a callable that restores original forward methods.
+    """
+    dm = transformer
+    double_blocks = list(dm.transformer_blocks)
+    single_blocks = list(dm.single_transformer_blocks)
+
+    orig_d: dict[int, object] = {}
+    orig_s: dict[int, object] = {}
+
+    ca_idx = 0
+
+    for idx, block in enumerate(double_blocks):
+        if idx % _DOUBLE_INTERVAL != 0:
+            continue
+        orig_d[idx] = block.forward
+        local_ca_idx = ca_idx
+        ca_idx += 1
+
+        def make_double(i: int, ci: int):
+            def patched(
+                hidden_states: torch.Tensor = None,
+                encoder_hidden_states: torch.Tensor = None,
+                temb: torch.Tensor = None,
+                image_rotary_emb=None,
+                joint_attention_kwargs=None,
+            ):
+                enc_hs, img_hs = orig_d[i](
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                )
+                correction = pulid.pulid_ca[ci](id_tokens, img_hs)
+                return enc_hs, img_hs + strength * correction
+
+            return patched
+
+        block.forward = make_double(idx, local_ca_idx)
+
+    for idx, block in enumerate(single_blocks):
+        if idx % _SINGLE_INTERVAL != 0:
+            continue
+        orig_s[idx] = block.forward
+        local_ca_idx = ca_idx
+        ca_idx += 1
+
+        def make_single(i: int, ci: int):
+            def patched(
+                hidden_states: torch.Tensor = None,
+                encoder_hidden_states: torch.Tensor = None,
+                temb: torch.Tensor = None,
+                image_rotary_emb=None,
+                joint_attention_kwargs=None,
+            ):
+                # FluxSingleTransformerBlock.forward internally concatenates
+                # encoder_hidden_states + hidden_states, processes them, then
+                # splits and returns (encoder_hidden_states, hidden_states).
+                # The returned hidden_states is already the image-only stream.
+                out_enc, out_img = orig_s[i](
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                )
+                correction = pulid.pulid_ca[ci](id_tokens, out_img)
+                return out_enc, out_img + strength * correction
+
+            return patched
+
+        block.forward = make_single(idx, local_ca_idx)
+
+    def unpatch() -> None:
+        for i, block in enumerate(double_blocks):
+            if i in orig_d:
+                block.forward = orig_d[i]
+        for i, block in enumerate(single_blocks):
+            if i in orig_s:
+                block.forward = orig_s[i]
+
+    return unpatch

--- a/src/imagecli/engines/pulid_flux1_dev.py
+++ b/src/imagecli/engines/pulid_flux1_dev.py
@@ -18,367 +18,22 @@ VRAM profile (with enable_model_cpu_offload):
 from __future__ import annotations
 
 import logging
-import math
 from pathlib import Path
 
 import numpy as np
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 
 from imagecli.engine import EngineCapabilities, ImageEngine
+from imagecli.engines._pulid import PuLIDFlux1, patch_flux1
 
 logger = logging.getLogger(__name__)
 
 _PULID_WEIGHTS = Path.home() / "ComfyUI/models/pulid/pulid_flux_v0.9.1.safetensors"
 _INSIGHTFACE_DIR = Path.home() / "ComfyUI/models/insightface"
 
-# Block schedule constants — match PuLID FLUX.1 reference implementation
-_DOUBLE_INTERVAL = 2
-_SINGLE_INTERVAL = 4
-_N_DOUBLE = 19
-_N_SINGLE = 38
-
-# ceil(19/2)=10, ceil(38/4)=10 -> 20 CA modules total
-_NUM_CA = math.ceil(_N_DOUBLE / _DOUBLE_INTERVAL) + math.ceil(_N_SINGLE / _SINGLE_INTERVAL)
-
 # EVA-CLIP intermediate block indices (5 evenly-spaced layers across 24 ViT blocks)
 _EVA_INTERMEDIATE_INDICES = [4, 8, 12, 16, 20]
-
-
-# ── Inlined PuLID nn.Module classes ──────────────────────────────────────────
-# These match the weights in pulid_flux_v0.9.1.safetensors exactly.
-# Do NOT import from the PuLID repo — keep this file self-contained.
-
-
-def _reshape_tensor(x: torch.Tensor, heads: int) -> torch.Tensor:
-    bs, length, width = x.shape
-    x = x.view(bs, length, heads, -1)
-    x = x.transpose(1, 2)
-    return x.reshape(bs, heads, length, -1)
-
-
-class _PerceiverAttention(nn.Module):
-    """Self+cross attention used inside IDFormer (query attends to context + self)."""
-
-    def __init__(self, *, dim: int, dim_head: int = 64, heads: int = 8, kv_dim: int | None = None):
-        super().__init__()
-        self.dim_head = dim_head
-        self.heads = heads
-        inner_dim = dim_head * heads
-        kv = kv_dim if kv_dim is not None else dim
-        self.norm1 = nn.LayerNorm(kv)
-        self.norm2 = nn.LayerNorm(dim)
-        self.to_q = nn.Linear(dim, inner_dim, bias=False)
-        self.to_kv = nn.Linear(kv, inner_dim * 2, bias=False)
-        self.to_out = nn.Linear(inner_dim, dim, bias=False)
-
-    def forward(self, x: torch.Tensor, latents: torch.Tensor) -> torch.Tensor:
-        x = self.norm1(x)
-        latents = self.norm2(latents)
-        b, seq_len, _ = latents.shape
-        q = self.to_q(latents)
-        kv_input = torch.cat((x, latents), dim=-2)
-        k, v = self.to_kv(kv_input).chunk(2, dim=-1)
-        q, k, v = (_reshape_tensor(t, self.heads) for t in (q, k, v))
-        scale = 1 / math.sqrt(math.sqrt(self.dim_head))
-        weight = (q * scale) @ (k * scale).transpose(-2, -1)
-        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
-        out = weight @ v
-        out = out.permute(0, 2, 1, 3).reshape(b, seq_len, -1)
-        return self.to_out(out)
-
-
-def _FeedForward(dim: int, mult: int = 4) -> nn.Sequential:
-    inner = int(dim * mult)
-    return nn.Sequential(
-        nn.LayerNorm(dim),
-        nn.Linear(dim, inner, bias=False),
-        nn.GELU(),
-        nn.Linear(inner, dim, bias=False),
-    )
-
-
-class _IDFormer(nn.Module):
-    """Perceiver-resampler identity encoder.
-
-    Matches IDFormer(dim=1024, depth=10, dim_head=64, heads=16,
-                     num_id_token=5, num_queries=32, output_dim=2048).
-
-    Input:
-        x  — id_cond  (B, 1280)  = concat[insightface_512, eva_cls_768]
-        y  — id_vit_hidden  list[5] of (B, N, 1024)  multi-scale EVA features
-    Output:
-        (B, 32, 2048)  id_tokens consumed by PerceiverAttentionCA
-    """
-
-    def __init__(
-        self,
-        dim: int = 1024,
-        depth: int = 10,
-        dim_head: int = 64,
-        heads: int = 16,
-        num_id_token: int = 5,
-        num_queries: int = 32,
-        output_dim: int = 2048,
-        ff_mult: int = 4,
-    ):
-        super().__init__()
-        self.num_id_token = num_id_token
-        self.dim = dim
-        self.num_queries = num_queries
-        assert depth % 5 == 0
-        self.depth = depth // 5
-        scale = dim**-0.5
-
-        self.latents = nn.Parameter(torch.randn(1, num_queries, dim) * scale)
-        self.proj_out = nn.Parameter(scale * torch.randn(dim, output_dim))
-
-        self.layers = nn.ModuleList([])
-        for _ in range(depth):
-            self.layers.append(
-                nn.ModuleList(
-                    [
-                        _PerceiverAttention(dim=dim, dim_head=dim_head, heads=heads),
-                        _FeedForward(dim=dim, mult=ff_mult),
-                    ]
-                )
-            )
-
-        for i in range(5):
-            setattr(
-                self,
-                f"mapping_{i}",
-                nn.Sequential(
-                    nn.Linear(1024, 1024),
-                    nn.LayerNorm(1024),
-                    nn.LeakyReLU(),
-                    nn.Linear(1024, 1024),
-                    nn.LayerNorm(1024),
-                    nn.LeakyReLU(),
-                    nn.Linear(1024, dim),
-                ),
-            )
-
-        self.id_embedding_mapping = nn.Sequential(
-            nn.Linear(1280, 1024),
-            nn.LayerNorm(1024),
-            nn.LeakyReLU(),
-            nn.Linear(1024, 1024),
-            nn.LayerNorm(1024),
-            nn.LeakyReLU(),
-            nn.Linear(1024, dim * num_id_token),
-        )
-
-    def forward(self, x: torch.Tensor, y: list[torch.Tensor]) -> torch.Tensor:
-        latents = self.latents.repeat(x.size(0), 1, 1)
-        num_duotu = x.shape[1] if x.ndim == 3 else 1
-        x = self.id_embedding_mapping(x)
-        x = x.reshape(-1, self.num_id_token * num_duotu, self.dim)
-        latents = torch.cat((latents, x), dim=1)
-        for i in range(5):
-            vit_feature = getattr(self, f"mapping_{i}")(y[i])
-            ctx_feature = torch.cat((x, vit_feature), dim=1)
-            for attn, ff in self.layers[i * self.depth : (i + 1) * self.depth]:
-                latents = attn(ctx_feature, latents) + latents
-                latents = ff(latents) + latents
-        latents = latents[:, : self.num_queries]
-        latents = latents @ self.proj_out
-        return latents
-
-
-class _PerceiverAttentionCA(nn.Module):
-    """Cross-attention module that injects id_tokens into image hidden states.
-
-    Matches PerceiverAttentionCA(dim=3072, dim_head=128, heads=16, kv_dim=2048).
-
-    forward(x=id_tokens, latents=hidden_states) → correction (same shape as hidden_states)
-
-    Note: the weight file uses the BFL argument order: forward(id, img) which maps to
-    forward(x=id_tokens, latents=img_hidden_states). We preserve that convention.
-    """
-
-    def __init__(
-        self, *, dim: int = 3072, dim_head: int = 128, heads: int = 16, kv_dim: int = 2048
-    ):
-        super().__init__()
-        self.dim_head = dim_head
-        self.heads = heads
-        inner_dim = dim_head * heads  # 2048
-
-        self.norm1 = nn.LayerNorm(kv_dim)  # norm for id_tokens (kv_dim=2048)
-        self.norm2 = nn.LayerNorm(dim)  # norm for hidden_states (dim=3072)
-
-        self.to_q = nn.Linear(dim, inner_dim, bias=False)  # hidden -> queries
-        self.to_kv = nn.Linear(kv_dim, inner_dim * 2, bias=False)  # id -> k,v
-        self.to_out = nn.Linear(inner_dim, dim, bias=False)  # -> dim=3072
-
-    def forward(self, id_tokens: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
-        """
-        Args:
-            id_tokens:     (B, 32, 2048)  output of IDFormer
-            hidden_states: (B, N, 3072)   image stream from transformer block
-        Returns:
-            correction:    (B, N, 3072)   to be added (scaled) to hidden_states
-        """
-        dtype = self.norm2.weight.dtype
-        id_tokens = id_tokens.to(dtype)
-        hidden_states = hidden_states.to(dtype)
-
-        id_n = self.norm1(id_tokens)  # (B, 32, 2048)
-        hs_n = self.norm2(hidden_states)  # (B, N, 3072)
-
-        b, seq_len, _ = hidden_states.shape
-
-        q = self.to_q(hs_n)  # (B, N, 2048)
-        k, v = self.to_kv(id_n).chunk(2, dim=-1)  # each (B, 32, 2048)
-
-        q, k, v = (_reshape_tensor(t, self.heads) for t in (q, k, v))
-        # q: (B, heads, N, dim_head)  k,v: (B, heads, 32, dim_head)
-
-        scale = 1 / math.sqrt(math.sqrt(self.dim_head))
-        weight = (q * scale) @ (k * scale).transpose(-2, -1)  # (B, heads, N, 32)
-        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
-        out = weight @ v  # (B, heads, N, dim_head)
-
-        out = out.permute(0, 2, 1, 3).reshape(b, seq_len, -1)  # (B, N, 2048)
-        return self.to_out(out)  # (B, N, 3072)
-
-
-class _PuLIDFlux1(nn.Module):
-    """Container for PuLID FLUX.1 weights — IDFormer + 20 CA modules."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.pulid_encoder = _IDFormer()
-        self.pulid_ca = nn.ModuleList([_PerceiverAttentionCA() for _ in range(_NUM_CA)])
-
-    @classmethod
-    def from_safetensors(cls, path: Path) -> "_PuLIDFlux1":
-        from safetensors.torch import load_file
-
-        state = load_file(str(path), device="cpu")
-        # Keys use 'pulid_encoder.*' and 'pulid_ca.*' prefixes — map directly
-        model = cls()
-        missing, unexpected = model.load_state_dict(state, strict=False)
-        if missing:
-            logger.warning("PuLID weights: missing keys: %s", missing[:5])
-        if unexpected:
-            logger.warning("PuLID weights: unexpected keys: %s", unexpected[:5])
-        return model
-
-
-# ── transformer patching ──────────────────────────────────────────────────────
-
-
-def _patch_flux1(
-    transformer: object,
-    pulid: _PuLIDFlux1,
-    id_tokens: torch.Tensor,
-    strength: float,
-) -> object:
-    """Monkey-patch FLUX.1-dev diffusers transformer blocks to inject PuLID identity.
-
-    Double blocks (FluxTransformerBlock):
-        - Every _DOUBLE_INTERVAL-th block (0, 2, 4, ...) gets a correction on
-          hidden_states (image stream).
-        - forward signature: (hidden_states, encoder_hidden_states, temb,
-                               image_rotary_emb, joint_attention_kwargs)
-          returns: (encoder_hidden_states, hidden_states)
-
-    Single blocks (FluxSingleTransformerBlock):
-        - Every _SINGLE_INTERVAL-th block (0, 4, 8, ...) gets a correction on
-          hidden_states (image stream, AFTER txt split).
-        - forward signature: same as double block
-          returns: (encoder_hidden_states, hidden_states)
-          Internally concatenates txt+img, processes them, then splits back.
-          The returned hidden_states is already the image-only portion.
-
-    Returns a callable that restores original forward methods.
-    """
-    dm = transformer
-    double_blocks = list(dm.transformer_blocks)
-    single_blocks = list(dm.single_transformer_blocks)
-
-    orig_d: dict[int, object] = {}
-    orig_s: dict[int, object] = {}
-
-    ca_idx = 0
-
-    for idx, block in enumerate(double_blocks):
-        if idx % _DOUBLE_INTERVAL != 0:
-            continue
-        orig_d[idx] = block.forward
-        local_ca_idx = ca_idx
-        ca_idx += 1
-
-        def make_double(i: int, ci: int):
-            def patched(
-                hidden_states: torch.Tensor = None,
-                encoder_hidden_states: torch.Tensor = None,
-                temb: torch.Tensor = None,
-                image_rotary_emb=None,
-                joint_attention_kwargs=None,
-            ):
-                enc_hs, img_hs = orig_d[i](
-                    hidden_states=hidden_states,
-                    encoder_hidden_states=encoder_hidden_states,
-                    temb=temb,
-                    image_rotary_emb=image_rotary_emb,
-                    joint_attention_kwargs=joint_attention_kwargs,
-                )
-                correction = pulid.pulid_ca[ci](id_tokens, img_hs)
-                return enc_hs, img_hs + strength * correction
-
-            return patched
-
-        block.forward = make_double(idx, local_ca_idx)
-
-    for idx, block in enumerate(single_blocks):
-        if idx % _SINGLE_INTERVAL != 0:
-            continue
-        orig_s[idx] = block.forward
-        local_ca_idx = ca_idx
-        ca_idx += 1
-
-        def make_single(i: int, ci: int):
-            def patched(
-                hidden_states: torch.Tensor = None,
-                encoder_hidden_states: torch.Tensor = None,
-                temb: torch.Tensor = None,
-                image_rotary_emb=None,
-                joint_attention_kwargs=None,
-            ):
-                # FluxSingleTransformerBlock.forward internally concatenates
-                # encoder_hidden_states + hidden_states, processes them, then
-                # splits and returns (encoder_hidden_states, hidden_states).
-                # The returned hidden_states is already the image-only stream.
-                out_enc, out_img = orig_s[i](
-                    hidden_states=hidden_states,
-                    encoder_hidden_states=encoder_hidden_states,
-                    temb=temb,
-                    image_rotary_emb=image_rotary_emb,
-                    joint_attention_kwargs=joint_attention_kwargs,
-                )
-                correction = pulid.pulid_ca[ci](id_tokens, out_img)
-                return out_enc, out_img + strength * correction
-
-            return patched
-
-        block.forward = make_single(idx, local_ca_idx)
-
-    def unpatch() -> None:
-        for i, block in enumerate(double_blocks):
-            if i in orig_d:
-                block.forward = orig_d[i]
-        for i, block in enumerate(single_blocks):
-            if i in orig_s:
-                block.forward = orig_s[i]
-
-    return unpatch
-
-
-# ── engine ─────────────────────────────────────────────────────────────────────
 
 GGUF_REPO = "city96/FLUX.1-dev-gguf"
 GGUF_FILE = "flux1-dev-Q5_K_S.gguf"
@@ -394,7 +49,7 @@ class PuLIDFlux1DevEngine(ImageEngine):
     def __init__(self, *, compile: bool = True) -> None:
         # torch.compile captures original forward methods — incompatible with per-generation patching
         super().__init__(compile=False)
-        self._pulid: _PuLIDFlux1 | None = None
+        self._pulid: PuLIDFlux1 | None = None
         self._insightface: object | None = None
         self._eva_clip_trunk: object | None = None
         self._eva_clip_head: object | None = None
@@ -426,7 +81,7 @@ class PuLIDFlux1DevEngine(ImageEngine):
         self._optimize_pipe(self._pipe)
 
         logger.info("Loading PuLID weights from %s…", _PULID_WEIGHTS)
-        self._pulid = _PuLIDFlux1.from_safetensors(_PULID_WEIGHTS)
+        self._pulid = PuLIDFlux1.from_safetensors(_PULID_WEIGHTS)
         self._pulid.eval().to("cuda", dtype=torch.bfloat16)
 
         logger.info("Loading InsightFace (AntelopeV2)…")
@@ -549,7 +204,7 @@ class PuLIDFlux1DevEngine(ImageEngine):
             gc.collect()
             torch.cuda.empty_cache()
 
-        unpatch = _patch_flux1(
+        unpatch = patch_flux1(
             self._pipe.transformer, self._pulid, self._cached_id_tokens, pulid_strength
         )
         try:

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -1,7 +1,6 @@
 # Exemptions — file_length gate
 # Format: <path> <issue-url>  (single-space separator)
 # Each entry MUST reference a tracking issue so the exemption is recoverable.
-src/imagecli/engines/pulid_flux1_dev.py https://github.com/Roxabi/imageCLI/issues/55
 src/imagecli/engines/pulid_flux2_klein.py https://github.com/Roxabi/imageCLI/issues/56
 src/imagecli/engines/flux2_klein_fp4.py https://github.com/Roxabi/imageCLI/issues/58
 src/imagecli/daemon.py https://github.com/Roxabi/imageCLI/issues/59


### PR DESCRIPTION
## Summary
- Extract PuLID nn.Modules (IDFormer, PerceiverAttention, PerceiverAttentionCA, PuLIDFlux1) and the FLUX.1-dev transformer monkey-patcher out of `pulid_flux1_dev.py` (569 LOC) into a private `engines/_pulid/` sub-package so the engine clears the 300 LOC file-length gate.
- Engine file now 224 LOC; sub-package: `modules.py` (244), `patching.py` (121), `__init__.py` (20). `#55` exemption removed from `tools/file_exemptions.txt`.
- Behavior unchanged — PuLID v0.9.1 face-lock path identical; no `torch.compile`; VRAM profile untouched.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #55: refactor(engines): split src/imagecli/engines/pulid_flux1_dev.py (569 LOC) | OPEN |
| Frame | [55-split-pulid-flux1-dev-frame.mdx](artifacts/frames/55-split-pulid-flux1-dev-frame.mdx) | Present (on staging) |
| Spec | [55-split-pulid-flux1-dev-spec.mdx](artifacts/specs/55-split-pulid-flux1-dev-spec.mdx) | Present (on staging) |
| Plan | [55-split-pulid-flux1-dev-plan.mdx](artifacts/plans/55-split-pulid-flux1-dev-plan.mdx) | Present (on staging) |
| Implementation | 1 commit on `feat/55-split-pulid-flux1-dev` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (148 passed, 4 xfailed, 3 xpassed) | Passed |

## Test Plan
- [x] `uv run ruff check .` passes on sub-package + engine
- [x] `uv run pytest` — 148 passed
- [x] `bash tools/check_file_length.sh` — exit 0 (all engine files <300 LOC)
- [x] `bash tools/check_folder_size.sh` — exit 0 (`_pulid/` has 3 files)
- [x] `imagecli engines` still lists `pulid-flux1-dev` with unchanged description
- [ ] **Manual smoke-test before merge**: `imagecli generate <prompt.md> -e pulid-flux1-dev --seed 42` with a known `face_image` — verify identity-lock output matches pre-refactor golden image (T0/T7 golden regression task in plan was deferred: requires GPU + real PuLID weights, out of CI scope).

Closes #55

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`