### PR TITLE
refactor(engines): split flux2_klein_fp4.py into sibling modules

### DIFF
--- a/src/imagecli/engines/flux2_klein_fp4.py
+++ b/src/imagecli/engines/flux2_klein_fp4.py
@@ -21,10 +21,6 @@ from pathlib import Path
 from typing import ClassVar
 
 from imagecli.engine import EngineCapabilities, ImageEngine
-from imagecli.engines.nvfp4_quantize import (
-    patch_transformer_nvfp4,
-    runtime_quantize_transformer_to_nvfp4,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +64,11 @@ class Flux2KleinFP4Engine(ImageEngine):
         import torch
         from diffusers import Flux2KleinPipeline
         from huggingface_hub import hf_hub_download
+
+        from imagecli.engines.nvfp4_quantize import (
+            patch_transformer_nvfp4,
+            runtime_quantize_transformer_to_nvfp4,
+        )
 
         logger.info("Loading base pipeline %s...", BASE_REPO)
         self._pipe = Flux2KleinPipeline.from_pretrained(BASE_REPO, torch_dtype=torch.bfloat16)

--- a/src/imagecli/engines/flux2_klein_fp4.py
+++ b/src/imagecli/engines/flux2_klein_fp4.py
@@ -21,257 +21,16 @@ from pathlib import Path
 from typing import ClassVar
 
 from imagecli.engine import EngineCapabilities, ImageEngine
+from imagecli.engines.nvfp4_quantize import (
+    patch_transformer_nvfp4,
+    runtime_quantize_transformer_to_nvfp4,
+)
 
 logger = logging.getLogger(__name__)
 
 NVFP4_REPO = "black-forest-labs/FLUX.2-klein-4b-nvfp4"
 NVFP4_FILENAME = "flux-2-klein-4b-nvfp4.safetensors"
 BASE_REPO = "black-forest-labs/FLUX.2-klein-4B"
-
-# ── BFL → diffusers key mapping (same as diffusers single_file_utils.py) ─────
-
-_RENAME = {
-    "img_in": "x_embedder",
-    "txt_in": "context_embedder",
-    "time_in.in_layer": "time_guidance_embed.timestep_embedder.linear_1",
-    "time_in.out_layer": "time_guidance_embed.timestep_embedder.linear_2",
-    "guidance_in.in_layer": "time_guidance_embed.guidance_embedder.linear_1",
-    "guidance_in.out_layer": "time_guidance_embed.guidance_embedder.linear_2",
-    "double_stream_modulation_img.lin": "double_stream_modulation_img.linear",
-    "double_stream_modulation_txt.lin": "double_stream_modulation_txt.linear",
-    "single_stream_modulation.lin": "single_stream_modulation.linear",
-    "final_layer.linear": "proj_out",
-}
-
-_DOUBLE_BLOCK_MAP = {
-    "img_attn.norm.query_norm": "attn.norm_q",
-    "img_attn.norm.key_norm": "attn.norm_k",
-    "img_attn.proj": "attn.to_out.0",
-    "img_mlp.0": "ff.linear_in",
-    "img_mlp.2": "ff.linear_out",
-    "txt_attn.norm.query_norm": "attn.norm_added_q",
-    "txt_attn.norm.key_norm": "attn.norm_added_k",
-    "txt_attn.proj": "attn.to_add_out",
-    "txt_mlp.0": "ff_context.linear_in",
-    "txt_mlp.2": "ff_context.linear_out",
-}
-
-_SINGLE_BLOCK_MAP = {
-    "linear1": "attn.to_qkv_mlp_proj",
-    "linear2": "attn.to_out",
-    "norm.query_norm": "attn.norm_q",
-    "norm.key_norm": "attn.norm_k",
-}
-
-# NVFP4 tensor suffixes: each linear layer has these 4 tensors
-_NVFP4_SUFFIXES = (".weight", ".weight_scale", ".weight_scale_2", ".input_scale")
-
-
-def _convert_nvfp4_state_dict(raw: dict[str, object]) -> dict[str, object]:
-    """Convert BFL NVFP4 state dict keys to diffusers naming, splitting fused QKV."""
-    import torch
-
-    out: dict[str, object] = {}
-
-    # Step 1: Simple renames
-    for old_key in list(raw.keys()):
-        new_key = old_key
-        for old, new in _RENAME.items():
-            new_key = new_key.replace(old, new)
-        if new_key != old_key:
-            raw[new_key] = raw.pop(old_key)
-
-    # Step 2: Double blocks — handle QKV split and non-QKV remap
-    for key in list(raw.keys()):
-        if "double_blocks." not in key:
-            continue
-
-        parts = key.split(".")
-        block_idx = parts[1]
-        # Reconstruct the within-block name (everything between block idx and the last part)
-        # e.g. "double_blocks.0.img_attn.qkv.weight" → within="img_attn.qkv", suffix=".weight"
-        rest = ".".join(parts[2:])
-
-        # Check for NVFP4 suffix
-        suffix = None
-        for s in _NVFP4_SUFFIXES + (".scale",):
-            if rest.endswith(s.lstrip(".")):
-                suffix = rest[rest.rindex(s.lstrip(".")) - 1:]  # include the dot
-                within = rest[: rest.rindex(s.lstrip(".")) - 1]
-                break
-        if suffix is None:
-            # Regular weight/bias
-            within = ".".join(parts[2:-1])
-            suffix = "." + parts[-1]
-
-        if suffix == ".scale":
-            suffix = ".weight"
-
-        if "qkv" in within:
-            # Fused QKV → split into Q, K, V (split dim=0 into 3 chunks)
-            tensor = raw.pop(key)
-            if tensor.dim() >= 1:
-                chunks = torch.chunk(tensor, 3, dim=0)
-            else:
-                # Scalar (e.g. weight_scale_2, input_scale) — duplicate for each
-                chunks = (tensor, tensor, tensor)
-
-            if "img" in within:
-                names = ("attn.to_q", "attn.to_k", "attn.to_v")
-            else:
-                names = ("attn.add_q_proj", "attn.add_k_proj", "attn.add_v_proj")
-
-            for name, chunk in zip(names, chunks):
-                out_key = f"transformer_blocks.{block_idx}.{name}{suffix}"
-                out[out_key] = chunk
-        else:
-            # Non-QKV — simple remap
-            if within in _DOUBLE_BLOCK_MAP:
-                new_within = _DOUBLE_BLOCK_MAP[within]
-                out_key = f"transformer_blocks.{block_idx}.{new_within}{suffix}"
-                out[out_key] = raw.pop(key)
-
-    # Step 3: Single blocks — simple remap
-    for key in list(raw.keys()):
-        if "single_blocks." not in key:
-            continue
-
-        parts = key.split(".")
-        block_idx = parts[1]
-        rest = ".".join(parts[2:])
-
-        suffix = None
-        for s in _NVFP4_SUFFIXES + (".scale",):
-            if rest.endswith(s.lstrip(".")):
-                suffix = rest[rest.rindex(s.lstrip(".")) - 1:]
-                within = rest[: rest.rindex(s.lstrip(".")) - 1]
-                break
-        if suffix is None:
-            within = ".".join(parts[2:-1])
-            suffix = "." + parts[-1]
-
-        if suffix == ".scale":
-            suffix = ".weight"
-
-        if within in _SINGLE_BLOCK_MAP:
-            new_within = _SINGLE_BLOCK_MAP[within]
-            out_key = f"single_transformer_blocks.{block_idx}.{new_within}{suffix}"
-            out[out_key] = raw.pop(key)
-
-    # Step 4: Anything remaining (already renamed in step 1)
-    for key, val in raw.items():
-        if key not in out:
-            out[key] = val
-
-    return out
-
-
-def _runtime_quantize_transformer_to_nvfp4(transformer) -> int:
-    """Runtime-quantize all nn.Linear weights in the transformer to NVFP4.
-
-    Used when a LoRA has been fused into the bf16 base weights — we cannot use
-    the pre-quantized disk weights because they encode the un-fused model.
-    Instead we quantize the (LoRA-fused) bf16 weights on the fly via
-    QuantizedTensor.from_float(w, "TensorCoreNVFP4Layout").
-
-    Returns the number of layers quantized.
-    """
-    import torch
-    from comfy_kitchen.tensor import QuantizedTensor
-
-    quantized = 0
-    for module in transformer.modules():
-        if not isinstance(module, torch.nn.Linear):
-            continue
-        w = module.weight.data
-        if w.dtype != torch.bfloat16:
-            continue  # already quantized or wrong dtype
-        qt = QuantizedTensor.from_float(
-            w.to("cuda"), layout_cls="TensorCoreNVFP4Layout"
-        )
-        module.weight = torch.nn.Parameter(qt, requires_grad=False)
-        quantized += 1
-    return quantized
-
-
-def _patch_transformer_nvfp4(transformer, nvfp4_path: str) -> int:
-    """Replace linear layer weights with NVFP4 QuantizedTensors."""
-    import torch
-    from comfy_kitchen.tensor import QuantizedTensor
-    from comfy_kitchen.tensor.nvfp4 import TensorCoreNVFP4Layout as NVFP4
-    from safetensors import safe_open
-
-    # Load and convert BFL keys to diffusers keys
-    with safe_open(nvfp4_path, framework="pt", device="cuda") as f:
-        raw = {k: f.get_tensor(k) for k in f.keys()}
-
-    converted = _convert_nvfp4_state_dict(raw)
-
-    # Group by layer: find layers that have .weight (uint8) + .weight_scale + .weight_scale_2
-    layers: dict[str, dict[str, object]] = {}
-    for key, tensor in converted.items():
-        for suffix in _NVFP4_SUFFIXES:
-            if key.endswith(suffix):
-                layer_name = key[: -len(suffix)]
-                layers.setdefault(layer_name, {})[suffix] = tensor
-                break
-
-    patched = 0
-    for layer_name, tensors in layers.items():
-        if ".weight" not in tensors or ".weight_scale" not in tensors:
-            continue
-
-        weight = tensors[".weight"]
-        if weight.dtype != torch.uint8:
-            continue  # Not a quantized layer
-
-        block_scale = tensors[".weight_scale"]
-        global_scale = tensors.get(".weight_scale_2", torch.tensor(1.0, dtype=torch.float32))
-
-        orig_shape = (weight.shape[0], weight.shape[1] * 2)
-        params = NVFP4.Params(
-            scale=global_scale.to("cuda"),
-            orig_dtype=torch.bfloat16,
-            orig_shape=orig_shape,
-            block_scale=block_scale.to("cuda"),
-        )
-        qt = QuantizedTensor(weight.to("cuda"), layout_cls="TensorCoreNVFP4Layout", params=params)
-
-        # Find the module and replace its weight
-        parts = layer_name.split(".")
-        module = transformer
-        for part in parts:
-            module = getattr(module, part, None)
-            if module is None:
-                break
-
-        if module is not None and isinstance(module, torch.nn.Linear):
-            module.weight = torch.nn.Parameter(qt, requires_grad=False)
-            patched += 1
-
-    # Also load non-quantized weights (norm scales, biases)
-    for key, tensor in converted.items():
-        is_nvfp4 = any(key.endswith(s) for s in _NVFP4_SUFFIXES)
-        if is_nvfp4:
-            continue
-        # Try to set this parameter on the transformer
-        parts = key.rsplit(".", 1)
-        if len(parts) != 2:
-            continue
-        module_path, param_name = parts
-        module = transformer
-        for part in module_path.split("."):
-            module = getattr(module, part, None)
-            if module is None:
-                break
-        if module is not None and hasattr(module, param_name):
-            param = getattr(module, param_name)
-            if isinstance(param, torch.nn.Parameter):
-                param.data.copy_(tensor.to(param.device))
-            elif isinstance(param, torch.Tensor):
-                param.copy_(tensor.to(param.device))
-
-    return patched
 
 
 class Flux2KleinFP4Engine(ImageEngine):
@@ -289,9 +48,7 @@ class Flux2KleinFP4Engine(ImageEngine):
             raise RuntimeError("NVFP4 requires a CUDA GPU.")
         sm = torch.cuda.get_device_capability()
         if sm < (12, 0):
-            raise RuntimeError(
-                f"NVFP4 requires Blackwell GPU (sm_120+), got sm_{sm[0]}{sm[1]}."
-            )
+            raise RuntimeError(f"NVFP4 requires Blackwell GPU (sm_120+), got sm_{sm[0]}{sm[1]}.")
         cuda_ver = torch.version.cuda
         if cuda_ver and int(cuda_ver.split(".")[0]) < 13:
             raise RuntimeError(f"NVFP4 requires CUDA 13.0+ (cu130), got {cuda_ver}.")
@@ -313,9 +70,7 @@ class Flux2KleinFP4Engine(ImageEngine):
         from huggingface_hub import hf_hub_download
 
         logger.info("Loading base pipeline %s...", BASE_REPO)
-        self._pipe = Flux2KleinPipeline.from_pretrained(
-            BASE_REPO, torch_dtype=torch.bfloat16
-        )
+        self._pipe = Flux2KleinPipeline.from_pretrained(BASE_REPO, torch_dtype=torch.bfloat16)
 
         if self.lora_path:
             # LoRA path: fuse LoRA into bf16 base, then runtime-quantize the fused
@@ -338,7 +93,7 @@ class Flux2KleinFP4Engine(ImageEngine):
 
             self._pipe.transformer.to("cuda")
             logger.info("Runtime-quantizing fused transformer to NVFP4...")
-            patched = _runtime_quantize_transformer_to_nvfp4(self._pipe.transformer)
+            patched = runtime_quantize_transformer_to_nvfp4(self._pipe.transformer)
             logger.info("Runtime-quantized %d linear layers to NVFP4.", patched)
         else:
             # Pivotal-only path: standalone embedding file without a LoRA.
@@ -352,7 +107,7 @@ class Flux2KleinFP4Engine(ImageEngine):
 
             self._pipe.transformer.to("cuda")
             logger.info("Patching transformer with NVFP4 QuantizedTensors...")
-            patched = _patch_transformer_nvfp4(self._pipe.transformer, nvfp4_path)
+            patched = patch_transformer_nvfp4(self._pipe.transformer, nvfp4_path)
             logger.info("Patched %d linear layers with NVFP4 weights.", patched)
 
     def _set_execution_device(self):
@@ -363,8 +118,10 @@ class Flux2KleinFP4Engine(ImageEngine):
         if not hasattr(orig_cls, "_orig_execution_device"):
             orig_cls._orig_execution_device = orig_cls._execution_device
             orig_cls._execution_device = property(
-                lambda pipe: getattr(pipe, "_execution_device_override", None)
-                or orig_cls._orig_execution_device.fget(pipe)
+                lambda pipe: (
+                    getattr(pipe, "_execution_device_override", None)
+                    or orig_cls._orig_execution_device.fget(pipe)
+                )
             )
 
     def _load(self):
@@ -388,9 +145,16 @@ class Flux2KleinFP4Engine(ImageEngine):
         logger.info("All components on GPU — NVFP4 transformer.")
 
     def encode_and_generate(
-        self, prompt: str, *, width: int = 1024, height: int = 1024,
-        steps: int = 50, guidance: float = 4.0, seed: int | None = None,
-        output_path: Path, callback=None,
+        self,
+        prompt: str,
+        *,
+        width: int = 1024,
+        height: int = 1024,
+        steps: int = 50,
+        guidance: float = 4.0,
+        seed: int | None = None,
+        output_path: Path,
+        callback=None,
     ) -> Path:
         import random
         import torch
@@ -402,8 +166,11 @@ class Flux2KleinFP4Engine(ImageEngine):
             torch.cuda.reset_peak_memory_stats()
 
         pipe_kwargs = {
-            "prompt": prompt, "width": width, "height": height,
-            "num_inference_steps": steps, "guidance_scale": guidance,
+            "prompt": prompt,
+            "width": width,
+            "height": height,
+            "num_inference_steps": steps,
+            "guidance_scale": guidance,
             "generator": generator,
         }
         if callback is not None:
@@ -413,8 +180,13 @@ class Flux2KleinFP4Engine(ImageEngine):
             result = self._pipe(**pipe_kwargs)
 
         return self._save_image(
-            result.images[0], output_path,
-            seed=seed, steps=steps, guidance=guidance, width=width, height=height,
+            result.images[0],
+            output_path,
+            seed=seed,
+            steps=steps,
+            guidance=guidance,
+            width=width,
+            height=height,
         )
 
     # ── 2-phase batch ──────────────────────────────────────────────────────
@@ -429,7 +201,9 @@ class Flux2KleinFP4Engine(ImageEngine):
 
         with torch.inference_mode():
             prompt_embeds, text_ids = self._pipe.encode_prompt(
-                prompt=prompt, device="cuda", num_images_per_prompt=1,
+                prompt=prompt,
+                device="cuda",
+                num_images_per_prompt=1,
             )
         return {"prompt_embeds": prompt_embeds.cpu(), "text_ids": text_ids.cpu()}
 
@@ -446,9 +220,16 @@ class Flux2KleinFP4Engine(ImageEngine):
         logger.info("Generation phase ready (NVFP4 transformer + VAE on GPU).")
 
     def generate_from_embeddings(
-        self, embeddings: dict, *, width: int = 1024, height: int = 1024,
-        steps: int = 50, guidance: float = 4.0, seed: int | None = None,
-        output_path: Path, callback=None,
+        self,
+        embeddings: dict,
+        *,
+        width: int = 1024,
+        height: int = 1024,
+        steps: int = 50,
+        guidance: float = 4.0,
+        seed: int | None = None,
+        output_path: Path,
+        callback=None,
     ) -> Path:
         import random
         import torch
@@ -459,8 +240,11 @@ class Flux2KleinFP4Engine(ImageEngine):
 
         pipe_kwargs = {
             "prompt_embeds": embeddings["prompt_embeds"].to("cuda"),
-            "width": width, "height": height, "num_inference_steps": steps,
-            "guidance_scale": guidance, "generator": generator,
+            "width": width,
+            "height": height,
+            "num_inference_steps": steps,
+            "guidance_scale": guidance,
+            "generator": generator,
         }
         if callback is not None:
             pipe_kwargs["callback_on_step_end"] = callback
@@ -471,6 +255,11 @@ class Flux2KleinFP4Engine(ImageEngine):
             result = self._pipe(**pipe_kwargs)
 
         return self._save_image(
-            result.images[0], output_path,
-            seed=seed, steps=steps, guidance=guidance, width=width, height=height,
+            result.images[0],
+            output_path,
+            seed=seed,
+            steps=steps,
+            guidance=guidance,
+            width=width,
+            height=height,
         )

--- a/src/imagecli/engines/nvfp4_quantize.py
+++ b/src/imagecli/engines/nvfp4_quantize.py
@@ -1,0 +1,128 @@
+"""Runtime NVFP4 quantizer + pre-quantized weight patcher.
+
+Two helpers that both mutate a transformer's ``nn.Linear`` weights into
+``comfy_kitchen.QuantizedTensor`` (TensorCoreNVFP4Layout):
+
+- ``runtime_quantize_transformer_to_nvfp4`` — quantizes bf16 weights on the fly.
+  Used when a LoRA has been fused into the bf16 base; the pre-quantized disk
+  weights can no longer be applied because they encode the un-fused model.
+- ``patch_transformer_nvfp4`` — loads BFL's pre-quantized NVFP4 safetensors,
+  remaps keys to the diffusers layout, and installs the QuantizedTensors
+  directly. Non-NVFP4 params (norm scales, biases) are copied into place.
+
+Heavy imports (``torch``, ``comfy_kitchen``, ``safetensors``) stay
+function-local — nothing at import time.
+"""
+
+from __future__ import annotations
+
+from imagecli.engines.nvfp4_state_dict import (
+    NVFP4_SUFFIXES,
+    convert_nvfp4_state_dict,
+)
+
+
+def runtime_quantize_transformer_to_nvfp4(transformer) -> int:
+    """Runtime-quantize all nn.Linear weights in the transformer to NVFP4.
+
+    Used when a LoRA has been fused into the bf16 base weights — we cannot use
+    the pre-quantized disk weights because they encode the un-fused model.
+    Instead we quantize the (LoRA-fused) bf16 weights on the fly via
+    QuantizedTensor.from_float(w, "TensorCoreNVFP4Layout").
+
+    Returns the number of layers quantized.
+    """
+    import torch
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    quantized = 0
+    for module in transformer.modules():
+        if not isinstance(module, torch.nn.Linear):
+            continue
+        w = module.weight.data
+        if w.dtype != torch.bfloat16:
+            continue  # already quantized or wrong dtype
+        qt = QuantizedTensor.from_float(w.to("cuda"), layout_cls="TensorCoreNVFP4Layout")
+        module.weight = torch.nn.Parameter(qt, requires_grad=False)
+        quantized += 1
+    return quantized
+
+
+def patch_transformer_nvfp4(transformer, nvfp4_path: str) -> int:
+    """Replace linear layer weights with NVFP4 QuantizedTensors."""
+    import torch
+    from comfy_kitchen.tensor import QuantizedTensor
+    from comfy_kitchen.tensor.nvfp4 import TensorCoreNVFP4Layout as NVFP4
+    from safetensors import safe_open
+
+    # Load and convert BFL keys to diffusers keys
+    with safe_open(nvfp4_path, framework="pt", device="cuda") as f:
+        raw = {k: f.get_tensor(k) for k in f.keys()}
+
+    converted = convert_nvfp4_state_dict(raw)
+
+    # Group by layer: find layers that have .weight (uint8) + .weight_scale + .weight_scale_2
+    layers: dict[str, dict[str, object]] = {}
+    for key, tensor in converted.items():
+        for suffix in NVFP4_SUFFIXES:
+            if key.endswith(suffix):
+                layer_name = key[: -len(suffix)]
+                layers.setdefault(layer_name, {})[suffix] = tensor
+                break
+
+    patched = 0
+    for layer_name, tensors in layers.items():
+        if ".weight" not in tensors or ".weight_scale" not in tensors:
+            continue
+
+        weight = tensors[".weight"]
+        if weight.dtype != torch.uint8:
+            continue  # Not a quantized layer
+
+        block_scale = tensors[".weight_scale"]
+        global_scale = tensors.get(".weight_scale_2", torch.tensor(1.0, dtype=torch.float32))
+
+        orig_shape = (weight.shape[0], weight.shape[1] * 2)
+        params = NVFP4.Params(
+            scale=global_scale.to("cuda"),
+            orig_dtype=torch.bfloat16,
+            orig_shape=orig_shape,
+            block_scale=block_scale.to("cuda"),
+        )
+        qt = QuantizedTensor(weight.to("cuda"), layout_cls="TensorCoreNVFP4Layout", params=params)
+
+        # Find the module and replace its weight
+        parts = layer_name.split(".")
+        module = transformer
+        for part in parts:
+            module = getattr(module, part, None)
+            if module is None:
+                break
+
+        if module is not None and isinstance(module, torch.nn.Linear):
+            module.weight = torch.nn.Parameter(qt, requires_grad=False)
+            patched += 1
+
+    # Also load non-quantized weights (norm scales, biases)
+    for key, tensor in converted.items():
+        is_nvfp4 = any(key.endswith(s) for s in NVFP4_SUFFIXES)
+        if is_nvfp4:
+            continue
+        # Try to set this parameter on the transformer
+        parts = key.rsplit(".", 1)
+        if len(parts) != 2:
+            continue
+        module_path, param_name = parts
+        module = transformer
+        for part in module_path.split("."):
+            module = getattr(module, part, None)
+            if module is None:
+                break
+        if module is not None and hasattr(module, param_name):
+            param = getattr(module, param_name)
+            if isinstance(param, torch.nn.Parameter):
+                param.data.copy_(tensor.to(param.device))
+            elif isinstance(param, torch.Tensor):
+                param.copy_(tensor.to(param.device))
+
+    return patched

--- a/src/imagecli/engines/nvfp4_state_dict.py
+++ b/src/imagecli/engines/nvfp4_state_dict.py
@@ -1,0 +1,147 @@
+"""BFL → diffusers NVFP4 state-dict converter.
+
+Converts BFL's native NVFP4 key layout (fused QKV, ``*_blocks.N.img_attn.qkv``)
+to the diffusers layout (split Q/K/V, ``transformer_blocks.N.attn.to_q``) while
+preserving NVFP4 tensor suffixes (``.weight``, ``.weight_scale``,
+``.weight_scale_2``, ``.input_scale``).
+
+Self-contained: torch is imported lazily inside the converter; no imagecli
+imports.
+"""
+
+from __future__ import annotations
+
+_RENAME = {
+    "img_in": "x_embedder",
+    "txt_in": "context_embedder",
+    "time_in.in_layer": "time_guidance_embed.timestep_embedder.linear_1",
+    "time_in.out_layer": "time_guidance_embed.timestep_embedder.linear_2",
+    "guidance_in.in_layer": "time_guidance_embed.guidance_embedder.linear_1",
+    "guidance_in.out_layer": "time_guidance_embed.guidance_embedder.linear_2",
+    "double_stream_modulation_img.lin": "double_stream_modulation_img.linear",
+    "double_stream_modulation_txt.lin": "double_stream_modulation_txt.linear",
+    "single_stream_modulation.lin": "single_stream_modulation.linear",
+    "final_layer.linear": "proj_out",
+}
+
+_DOUBLE_BLOCK_MAP = {
+    "img_attn.norm.query_norm": "attn.norm_q",
+    "img_attn.norm.key_norm": "attn.norm_k",
+    "img_attn.proj": "attn.to_out.0",
+    "img_mlp.0": "ff.linear_in",
+    "img_mlp.2": "ff.linear_out",
+    "txt_attn.norm.query_norm": "attn.norm_added_q",
+    "txt_attn.norm.key_norm": "attn.norm_added_k",
+    "txt_attn.proj": "attn.to_add_out",
+    "txt_mlp.0": "ff_context.linear_in",
+    "txt_mlp.2": "ff_context.linear_out",
+}
+
+_SINGLE_BLOCK_MAP = {
+    "linear1": "attn.to_qkv_mlp_proj",
+    "linear2": "attn.to_out",
+    "norm.query_norm": "attn.norm_q",
+    "norm.key_norm": "attn.norm_k",
+}
+
+# NVFP4 tensor suffixes: each linear layer has these 4 tensors
+NVFP4_SUFFIXES = (".weight", ".weight_scale", ".weight_scale_2", ".input_scale")
+
+
+def convert_nvfp4_state_dict(raw: dict[str, object]) -> dict[str, object]:
+    """Convert BFL NVFP4 state dict keys to diffusers naming, splitting fused QKV."""
+    import torch
+
+    out: dict[str, object] = {}
+
+    # Step 1: Simple renames
+    for old_key in list(raw.keys()):
+        new_key = old_key
+        for old, new in _RENAME.items():
+            new_key = new_key.replace(old, new)
+        if new_key != old_key:
+            raw[new_key] = raw.pop(old_key)
+
+    # Step 2: Double blocks — handle QKV split and non-QKV remap
+    for key in list(raw.keys()):
+        if "double_blocks." not in key:
+            continue
+
+        parts = key.split(".")
+        block_idx = parts[1]
+        # Reconstruct the within-block name (everything between block idx and the last part)
+        # e.g. "double_blocks.0.img_attn.qkv.weight" → within="img_attn.qkv", suffix=".weight"
+        rest = ".".join(parts[2:])
+
+        # Check for NVFP4 suffix
+        suffix = None
+        for s in NVFP4_SUFFIXES + (".scale",):
+            if rest.endswith(s.lstrip(".")):
+                suffix = rest[rest.rindex(s.lstrip(".")) - 1 :]  # include the dot
+                within = rest[: rest.rindex(s.lstrip(".")) - 1]
+                break
+        if suffix is None:
+            # Regular weight/bias
+            within = ".".join(parts[2:-1])
+            suffix = "." + parts[-1]
+
+        if suffix == ".scale":
+            suffix = ".weight"
+
+        if "qkv" in within:
+            # Fused QKV → split into Q, K, V (split dim=0 into 3 chunks)
+            tensor = raw.pop(key)
+            if tensor.dim() >= 1:
+                chunks = torch.chunk(tensor, 3, dim=0)
+            else:
+                # Scalar (e.g. weight_scale_2, input_scale) — duplicate for each
+                chunks = (tensor, tensor, tensor)
+
+            if "img" in within:
+                names = ("attn.to_q", "attn.to_k", "attn.to_v")
+            else:
+                names = ("attn.add_q_proj", "attn.add_k_proj", "attn.add_v_proj")
+
+            for name, chunk in zip(names, chunks):
+                out_key = f"transformer_blocks.{block_idx}.{name}{suffix}"
+                out[out_key] = chunk
+        else:
+            # Non-QKV — simple remap
+            if within in _DOUBLE_BLOCK_MAP:
+                new_within = _DOUBLE_BLOCK_MAP[within]
+                out_key = f"transformer_blocks.{block_idx}.{new_within}{suffix}"
+                out[out_key] = raw.pop(key)
+
+    # Step 3: Single blocks — simple remap
+    for key in list(raw.keys()):
+        if "single_blocks." not in key:
+            continue
+
+        parts = key.split(".")
+        block_idx = parts[1]
+        rest = ".".join(parts[2:])
+
+        suffix = None
+        for s in NVFP4_SUFFIXES + (".scale",):
+            if rest.endswith(s.lstrip(".")):
+                suffix = rest[rest.rindex(s.lstrip(".")) - 1 :]
+                within = rest[: rest.rindex(s.lstrip(".")) - 1]
+                break
+        if suffix is None:
+            within = ".".join(parts[2:-1])
+            suffix = "." + parts[-1]
+
+        if suffix == ".scale":
+            suffix = ".weight"
+
+        if within in _SINGLE_BLOCK_MAP:
+            new_within = _SINGLE_BLOCK_MAP[within]
+            out_key = f"single_transformer_blocks.{block_idx}.{new_within}{suffix}"
+            out[out_key] = raw.pop(key)
+
+    # Step 4: Anything remaining (already renamed in step 1)
+    for key, val in raw.items():
+        if key not in out:
+            out[key] = val
+
+    return out

--- a/src/imagecli/engines/nvfp4_state_dict.py
+++ b/src/imagecli/engines/nvfp4_state_dict.py
@@ -11,6 +11,8 @@ imports.
 
 from __future__ import annotations
 
+__all__ = ["NVFP4_SUFFIXES", "convert_nvfp4_state_dict"]
+
 _RENAME = {
     "img_in": "x_embedder",
     "txt_in": "context_embedder",
@@ -45,13 +47,17 @@ _SINGLE_BLOCK_MAP = {
 }
 
 # NVFP4 tensor suffixes: each linear layer has these 4 tensors
-NVFP4_SUFFIXES = (".weight", ".weight_scale", ".weight_scale_2", ".input_scale")
+NVFP4_SUFFIXES: tuple[str, ...] = (".weight", ".weight_scale", ".weight_scale_2", ".input_scale")
 
 
 def convert_nvfp4_state_dict(raw: dict[str, object]) -> dict[str, object]:
-    """Convert BFL NVFP4 state dict keys to diffusers naming, splitting fused QKV."""
+    """Convert BFL NVFP4 state dict keys to diffusers naming, splitting fused QKV.
+
+    Operates on a shallow copy of ``raw`` so the caller's dict is not consumed.
+    """
     import torch
 
+    raw = dict(raw)
     out: dict[str, object] = {}
 
     # Step 1: Simple renames

--- a/src/imagecli/engines/pulid_flux2_klein_fp4.py
+++ b/src/imagecli/engines/pulid_flux2_klein_fp4.py
@@ -1,6 +1,6 @@
 """FLUX.2-klein-4B + PuLID face identity lock, NVFP4-quantized — Blackwell only.
 
-Combines the NVFP4 runtime quantization path from flux2_klein_fp4 with the
+Combines the NVFP4 runtime quantization path from nvfp4_quantize with the
 PuLID CA activation injection from pulid_flux2_klein.
 
 Load path:

--- a/src/imagecli/engines/pulid_flux2_klein_fp4.py
+++ b/src/imagecli/engines/pulid_flux2_klein_fp4.py
@@ -63,8 +63,7 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
         sm = torch.cuda.get_device_capability()
         if sm < (12, 0):
             raise RuntimeError(
-                f"pulid-flux2-klein-fp4 requires Blackwell GPU (sm_120+), "
-                f"got sm_{sm[0]}{sm[1]}."
+                f"pulid-flux2-klein-fp4 requires Blackwell GPU (sm_120+), got sm_{sm[0]}{sm[1]}."
             )
         cuda_ver = torch.version.cuda
         if cuda_ver and int(cuda_ver.split(".")[0]) < 13:
@@ -118,7 +117,7 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
 
         from diffusers import Flux2KleinPipeline
 
-        from imagecli.engines.flux2_klein_fp4 import _runtime_quantize_transformer_to_nvfp4
+        from imagecli.engines.nvfp4_quantize import runtime_quantize_transformer_to_nvfp4
 
         logger.info("Loading Flux2Klein BF16 base for PuLID-FP4…")
         self._pipe = Flux2KleinPipeline.from_pretrained(
@@ -127,11 +126,11 @@ class PuLIDFlux2KleinFP4Engine(ImageEngine):
         )
 
         # Runtime-quantize transformer to NVFP4 — weights are moved to CUDA
-        # layer-by-layer inside _runtime_quantize_transformer_to_nvfp4, so no
+        # layer-by-layer inside runtime_quantize_transformer_to_nvfp4, so no
         # explicit transformer.to("cuda") is needed before quantization. This
         # avoids a ~10 GB BF16 peak that would occur if the full transformer
         # were moved to GPU before quantization begins.
-        n_quantized = _runtime_quantize_transformer_to_nvfp4(self._pipe.transformer)  # type: ignore[union-attr]
+        n_quantized = runtime_quantize_transformer_to_nvfp4(self._pipe.transformer)  # type: ignore[union-attr]
         logger.info("Runtime-quantized %d linear layers to NVFP4.", n_quantized)
 
         # Move remaining non-linear params (norms, biases, embeddings) to CUDA.

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -2,6 +2,5 @@
 # Format: <path> <issue-url>  (single-space separator)
 # Each entry MUST reference a tracking issue so the exemption is recoverable.
 src/imagecli/engines/pulid_flux2_klein.py https://github.com/Roxabi/imageCLI/issues/56
-src/imagecli/engines/flux2_klein_fp4.py https://github.com/Roxabi/imageCLI/issues/58
 src/imagecli/daemon.py https://github.com/Roxabi/imageCLI/issues/59
 src/imagecli/nats/adapter.py https://github.com/Roxabi/imageCLI/issues/60


### PR DESCRIPTION
## Summary
- Split 476-LOC `flux2_klein_fp4.py` into three files: engine class (265), `nvfp4_state_dict.py` converter + key maps (147), `nvfp4_quantize.py` runtime + patch helpers (128).
- Remove the file-length exemption installed by #53; update `pulid_flux2_klein_fp4.py` to import the runtime quantizer from its new home.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #58: refactor(engines): split src/imagecli/engines/flux2_klein_fp4.py (476 LOC) | OPEN |
| Frame | [58-split-flux2-klein-fp4-py-frame.mdx](artifacts/frames/58-split-flux2-klein-fp4-py-frame.mdx) | Present |
| Spec | [58-split-flux2-klein-fp4-py-spec.mdx](artifacts/specs/58-split-flux2-klein-fp4-py-spec.mdx) | Present |
| Plan | [58-split-flux2-klein-fp4-py-plan.mdx](artifacts/plans/58-split-flux2-klein-fp4-py-plan.mdx) | Present |
| Implementation | 1 commit on `feat/58-split-flux2-klein-fp4-py` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (148 passed, 0 new) Image parity ✅ (sha256 `6117c310…` byte-identical) | Passed |

## Test Plan
- [x] `uv run ruff check .` clean
- [x] `uv run pytest` — 148 passed
- [x] `bash tools/check_file_length.sh` clean (all three files <300 LOC)
- [x] `imagecli generate -e flux2-klein-fp4 --steps 8 --seed 42 --width 512 --height 512` — SHA-256 byte-identical to pre-split build (`6117c310f43766d295f85bb60a09748bbe3e92cde30705d36674d647ca019e8d`)
- [x] `uv run python -c "from imagecli.engines.pulid_flux2_klein_fp4 import PuLIDFlux2KleinFP4Engine"` resolves
- [ ] 2048² `--two-phase` VRAM ≤ 9.26 GB (deferred; image SHA parity is definitive correctness signal)
- [ ] `pulid-flux2-klein-fp4` end-to-end face-gen smoke (deferred; import resolution verified)

Closes #58

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`