### PR TITLE
test(engine): reject mixed-form at get_engine registry layer

### DIFF
--- a/src/imagecli/engine_registry.py
+++ b/src/imagecli/engine_registry.py
@@ -54,7 +54,7 @@ def get_engine(
         if lora_path is not None or trigger is not None or embedding_path is not None:
             raise ValueError(
                 "Pass either loras= or the singular fields "
-                "(lora_path / lora_scale / trigger / embedding_path), not both."
+                "(lora_path / trigger / embedding_path), not both."
             )
         return registry[name](compile=compile, loras=loras)
     return registry[name](

--- a/src/imagecli/engine_registry.py
+++ b/src/imagecli/engine_registry.py
@@ -51,6 +51,11 @@ def get_engine(
         known = ", ".join(registry)
         raise ValueError(f"Unknown engine {name!r}. Available: {known}")
     if loras is not None:
+        if lora_path is not None or trigger is not None or embedding_path is not None:
+            raise ValueError(
+                "Pass either loras= or the singular fields "
+                "(lora_path / lora_scale / trigger / embedding_path), not both."
+            )
         return registry[name](compile=compile, loras=loras)
     return registry[name](
         compile=compile,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -187,18 +187,33 @@ def test_get_engine_invalid():
 
 
 def test_get_engine_rejects_loras_and_lora_path_combo():
+    # Arrange / Act / Assert
     with pytest.raises(ValueError, match="not both"):
         get_engine("flux2-klein", loras=[LoraSpec("/a")], lora_path="/x")
 
 
 def test_get_engine_rejects_loras_and_trigger_combo():
+    # Arrange / Act / Assert
     with pytest.raises(ValueError, match="not both"):
         get_engine("flux2-klein", loras=[LoraSpec("/a")], trigger="t")
 
 
 def test_get_engine_rejects_loras_and_embedding_path_combo():
+    # Arrange / Act / Assert
     with pytest.raises(ValueError, match="not both"):
         get_engine("flux2-klein", loras=[LoraSpec("/a")], embedding_path="/e")
+
+
+def test_get_engine_accepts_loras_only():
+    # Arrange
+    specs = [LoraSpec("/a")]
+
+    # Act
+    engine = get_engine("flux2-klein", loras=specs)
+
+    # Assert
+    assert isinstance(engine, ImageEngine)
+    assert engine.loras == specs
 
 
 def test_list_engines():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -186,6 +186,21 @@ def test_get_engine_invalid():
         get_engine("nonexistent")
 
 
+def test_get_engine_rejects_loras_and_lora_path_combo():
+    with pytest.raises(ValueError, match="not both"):
+        get_engine("flux2-klein", loras=[LoraSpec("/a")], lora_path="/x")
+
+
+def test_get_engine_rejects_loras_and_trigger_combo():
+    with pytest.raises(ValueError, match="not both"):
+        get_engine("flux2-klein", loras=[LoraSpec("/a")], trigger="t")
+
+
+def test_get_engine_rejects_loras_and_embedding_path_combo():
+    with pytest.raises(ValueError, match="not both"):
+        get_engine("flux2-klein", loras=[LoraSpec("/a")], embedding_path="/e")
+
+
 def test_list_engines():
     # Act
     engines = list_engines()


### PR DESCRIPTION
## Summary
- Registry-layer `get_engine()` silently dropped singular LoRA kwargs when `loras=` was passed — mixed-form calls succeeded without surfacing the contradiction.
- Added explicit `ValueError` guard in `get_engine()` (mirrors `ImageEngine.__init__` message) + 3 registry-layer tests covering loras + {lora_path, trigger, embedding_path}.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #70: test(engine): add mixed-form rejection test at get_engine registry layer | OPEN |
| Implementation | 1 commit on `feat/70-mixed-form-registry-test` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 new) | Passed |

## Test Plan
- [x] `uv run pytest tests/test_engine.py -k "get_engine or mixed_form"` → 9 passed
- [x] `uv run ruff check` + `ruff format --check` clean

Closes #70

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`