### PR TITLE
fix(cli): coerce empty-string trigger to None in resolve_loras

### DIFF
--- a/src/imagecli/commands/_helpers.py
+++ b/src/imagecli/commands/_helpers.py
@@ -65,7 +65,7 @@ def resolve_loras(
             LoraSpec(
                 path=path,
                 scale=cli_scales[i] if cli_scales else 1.0,
-                trigger=cli_triggers[i] if cli_triggers else None,
+                trigger=(cli_triggers[i] or None) if cli_triggers else None,
                 embedding_path=cli_embeddings[i] if cli_embeddings else None,
             )
         )

--- a/tests/test_commands_helpers.py
+++ b/tests/test_commands_helpers.py
@@ -149,3 +149,9 @@ def test_resolve_loras_empty_cli_empty_fm_returns_empty() -> None:
     """Both empty → empty list, no error."""
     result = resolve_loras([], [], [], [], [])
     assert result == []
+
+
+def test_resolve_loras_empty_string_trigger_coerces_to_none() -> None:
+    """Pairwise empty-string trigger → None (not "")."""
+    result = resolve_loras(["/a.safetensors"], [], [""], [], [])
+    assert result[0].trigger is None


### PR DESCRIPTION
## Summary
- `resolve_loras` now coerces empty-string `cli_triggers[i]` to `None` (was flowing through as `trigger=""`).
- Applies the `or None` fallback per-element instead of only when the list itself is absent.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #71: resolve_loras should coerce empty-string trigger to None | Open |
| Implementation | 1 commit on `fix/71-resolve-loras-empty-trigger` | Complete |
| Verification | Lint ✅ Format ✅ Tests ✅ (1 new, `test_commands_helpers.py` 17/17) | Passed |

## Test Plan
- [x] `uv run pytest tests/test_commands_helpers.py` — 17 passed
- [x] New test `test_resolve_loras_empty_string_trigger_coerces_to_none` covers the `[\"\"]` case

Closes #71

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`