### PR TITLE
chore(engine): deprecate get_engine legacy singular-kwargs path

### DIFF
--- a/src/imagecli/engine_registry.py
+++ b/src/imagecli/engine_registry.py
@@ -5,6 +5,7 @@ the ABC module doesn't transitively import every concrete engine on startup.
 from __future__ import annotations
 
 import dataclasses
+import warnings
 
 from imagecli.engine_base import ImageEngine
 from imagecli.lora_spec import LoraSpec
@@ -57,6 +58,14 @@ def get_engine(
                 "(lora_path / trigger / embedding_path), not both."
             )
         return registry[name](compile=compile, loras=loras)
+    # TODO(v0.next-minor+1): remove legacy singular-kwargs branch after one release cycle.
+    if lora_path is not None or trigger is not None or embedding_path is not None:
+        warnings.warn(
+            "get_engine singular LoRA kwargs (lora_path, lora_scale, trigger, "
+            "embedding_path) are deprecated; pass loras=list[LoraSpec] instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     return registry[name](
         compile=compile,
         lora_path=lora_path,

--- a/src/imagecli/engine_registry.py
+++ b/src/imagecli/engine_registry.py
@@ -58,7 +58,7 @@ def get_engine(
                 "(lora_path / trigger / embedding_path), not both."
             )
         return registry[name](compile=compile, loras=loras)
-    # TODO(v0.next-minor+1): remove legacy singular-kwargs branch after one release cycle.
+    # TODO(#72): remove legacy singular-kwargs branch after one release cycle.
     if lora_path is not None or trigger is not None or embedding_path is not None:
         warnings.warn(
             "get_engine singular LoRA kwargs (lora_path, lora_scale, trigger, "

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -216,6 +216,30 @@ def test_get_engine_accepts_loras_only():
     assert engine.loras == specs
 
 
+def test_get_engine_legacy_kwargs_emits_deprecation_warning():
+    # Act / Assert: legacy singular kwargs fire DeprecationWarning
+    with pytest.warns(DeprecationWarning, match="singular LoRA kwargs"):
+        get_engine("flux2-klein", lora_path="/nonexistent.safetensors")
+
+
+def test_get_engine_loras_does_not_warn():
+    # Act: new plural form must not fire any warning
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        get_engine("flux2-klein", loras=[LoraSpec("/a")])
+
+
+def test_get_engine_no_lora_does_not_warn():
+    # Act: plain call (no LoRA at all) must not fire the deprecation warning
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        get_engine("flux2-klein")
+
+
 def test_list_engines():
     # Act
     engines = list_engines()


### PR DESCRIPTION
## Summary
- Emit `DeprecationWarning` from `get_engine` when callers pass legacy singular LoRA kwargs (`lora_path`, `trigger`, `embedding_path`) instead of `loras=list[LoraSpec]`.
- Gate the warning so it fires only when a legacy kwarg is actually set — no spurious noise on plain `get_engine("flux2-klein")` calls.
- `TODO(v0.next-minor+1)`: remove the legacy branch after one release cycle.

No behavior change. All internal callers already use `loras=`; the warning only fires for external callers on the deprecated path.

Closes #72

## Test plan
- [x] `uv run ruff format/check` clean
- [x] `uv run pytest tests/test_engine.py` — 46 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)