### PR TITLE
feat(nats): bump roxabi-nats v0.1.0 → v0.4.1 + adopt wait_ready=False

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ explicit = true
 torch = [{ index = "pytorch-cu130" }]
 torchvision = [{ index = "pytorch-cu130" }]
 diffusers = { git = "https://github.com/huggingface/diffusers.git", tag = "v0.37.1" }
-roxabi-nats = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats", tag = "roxabi-nats/v0.1.0" }
+roxabi-nats = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats", tag = "roxabi-nats/v0.4.1" }
 
 [tool.uv]
 override-dependencies = [

--- a/src/imagecli/nats/adapter.py
+++ b/src/imagecli/nats/adapter.py
@@ -27,6 +27,12 @@ SCHEMA_VERSION = "1"
 # Map legacy free-text error codes (kept for backward compat in `error: str`)
 # to structured WorkerError fields. `default_retryable` follows KNOWN_CODES
 # in roxabi_contracts.errors. Unmapped codes fall back to worker.internal.
+#
+# `delivery_failed` covers an OSError moving the generated file into
+# nats_out/ — generation succeeded but persistence failed. There is no
+# `image.delivery_failed` in KNOWN_CODES yet (request upstream), so we use
+# `worker.internal` per its docstring: "not covered by a more specific code."
+# Hub routing on `retryable=True` works identically to `worker.crash`.
 _WORKER_ERROR_MAP: dict[str, tuple[str, bool]] = {
     "missing_required_field": ("worker.validation", False),
     "unknown_engine": ("worker.validation", False),

--- a/src/imagecli/nats/adapter.py
+++ b/src/imagecli/nats/adapter.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import json
 import logging
 import shutil
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from roxabi_contracts.errors import WorkerError
+from roxabi_contracts.image import ImageResponse
 from roxabi_nats import NatsAdapterBase
 
 from imagecli.paths import move_to_nats_output
@@ -21,6 +23,24 @@ log = logging.getLogger(__name__)
 SUBJECT = "lyra.image.generate.request"
 HEARTBEAT_SUBJECT = "lyra.image.heartbeat"
 SCHEMA_VERSION = "1"
+
+# Map legacy free-text error codes (kept for backward compat in `error: str`)
+# to structured WorkerError fields. `default_retryable` follows KNOWN_CODES
+# in roxabi_contracts.errors. Unmapped codes fall back to worker.internal.
+_WORKER_ERROR_MAP: dict[str, tuple[str, bool]] = {
+    "missing_required_field": ("worker.validation", False),
+    "unknown_engine": ("worker.validation", False),
+    "engine_load_failed": ("image.engine_unavailable", True),
+    "insufficient_resources": ("worker.capacity", True),
+    "generation_failed": ("worker.crash", True),
+    "delivery_failed": ("worker.internal", True),
+}
+
+
+def _make_worker_error(code: str, detail: str | None = None) -> WorkerError:
+    """Build a structured WorkerError from a legacy free-text error code."""
+    canonical, retryable = _WORKER_ERROR_MAP.get(code, ("worker.internal", True))
+    return WorkerError(code=canonical, message=code, retryable=retryable, detail=detail)
 
 
 class ImageNatsAdapter(NatsAdapterBase):
@@ -58,13 +78,19 @@ class ImageNatsAdapter(NatsAdapterBase):
     async def handle(self, msg: Any, payload: dict) -> None:
         """Process an image generation request per ADR-046 contract."""
         request_id = payload.get("request_id", "")
+        # trace_id is required min_length=1 on the response envelope; fall back
+        # to request_id (then "unknown") so error paths can still produce a
+        # valid ImageResponse when the client omits it.
+        trace_id = payload.get("trace_id") or request_id or "unknown"
 
         # Acquire semaphore for concurrency control
         async with self._sem:
             # Validate required fields and bounds
             valid, error = _validate_request(payload)
             if not valid:
-                await self._reply_error(msg, request_id, "missing_required_field", error)
+                await self._reply_error(
+                    msg, trace_id, request_id, "missing_required_field", error
+                )
                 return
 
             engine_name = payload["engine"]
@@ -74,13 +100,15 @@ class ImageNatsAdapter(NatsAdapterBase):
             try:
                 from imagecli.engine import get_engine, preflight_check, list_engines
             except ImportError as e:
-                await self._reply_error(msg, request_id, "engine_load_failed", f"Import error: {e}")
+                await self._reply_error(
+                    msg, trace_id, request_id, "engine_load_failed", f"Import error: {e}"
+                )
                 return
 
             # Validate engine name against registry
             engine_names = {e["name"] for e in list_engines()}
             if engine_name not in engine_names:
-                await self._reply_error(msg, request_id, "unknown_engine", engine_name)
+                await self._reply_error(msg, trace_id, request_id, "unknown_engine", engine_name)
                 return
 
             # Get or create engine instance.
@@ -105,7 +133,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                 self._engine_loaded = engine_name
             except Exception as e:
                 error_code, error_detail = _map_exception_to_error(e)
-                await self._reply_error(msg, request_id, error_code, error_detail)
+                await self._reply_error(msg, trace_id, request_id, error_code, error_detail)
                 return
 
             # Preflight check (VRAM/RAM validation)
@@ -113,7 +141,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                 preflight_check(engine)
             except Exception as e:
                 error_code, error_detail = _map_exception_to_error(e)
-                await self._reply_error(msg, request_id, error_code, error_detail)
+                await self._reply_error(msg, trace_id, request_id, error_code, error_detail)
                 return
 
             # Extract generation params with defaults
@@ -159,7 +187,7 @@ class ImageNatsAdapter(NatsAdapterBase):
 
                     # Evict so the registry can reload cleanly next request.
                     model_registry.evict(engine_name)
-                await self._reply_error(msg, request_id, error_code, error_detail)
+                await self._reply_error(msg, trace_id, request_id, error_code, error_detail)
                 return
 
             # Read, encode, and deliver image.
@@ -171,19 +199,9 @@ class ImageNatsAdapter(NatsAdapterBase):
             try:
                 image_bytes = saved_path.read_bytes()
 
-                base_reply = {
-                    "contract_version": "1",
-                    "request_id": request_id,
-                    "ok": True,
-                    "mime_type": f"image/{fmt}",
-                    "width": width,
-                    "height": height,
-                    "engine": engine_name,
-                    "seed_used": seed if seed is not None else 0,
-                }
-
                 deliver_as_file = output_mode == "file"
                 image_b64: str | None = None
+                file_path_str: str | None = None
                 if not deliver_as_file:
                     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
                     # NATS server allows 50 MB but the contract caps base64
@@ -201,20 +219,40 @@ class ImageNatsAdapter(NatsAdapterBase):
                         # Distinct from generation_failed so the hub can route it.
                         log.exception(f"Failed to persist generated image: {move_err}")
                         await self._reply_error(
-                            msg, request_id, "delivery_failed", "Failed to persist image"
+                            msg,
+                            trace_id,
+                            request_id,
+                            "delivery_failed",
+                            "Failed to persist image",
                         )
                         return
-                    reply = {**base_reply, "file_path": str(final_path)}
-                else:
-                    reply = {**base_reply, "image_b64": image_b64}
+                    file_path_str = str(final_path)
 
-                await self.reply(msg, json.dumps(reply).encode())
+                resp = ImageResponse(
+                    contract_version="1",
+                    trace_id=trace_id,
+                    issued_at=datetime.now(timezone.utc),
+                    request_id=request_id,
+                    ok=True,
+                    image_b64=image_b64,
+                    file_path=file_path_str,
+                    mime_type=f"image/{fmt}",
+                    width=width,
+                    height=height,
+                    engine=engine_name,
+                    seed_used=seed if seed is not None else 0,
+                )
+                await self.reply(msg, resp.model_dump_json(exclude_none=True).encode())
                 reply_sent = True
 
             except Exception as e:
                 log.exception(f"Failed to encode response: {e}")
                 await self._reply_error(
-                    msg, request_id, "generation_failed", "Failed to encode response"
+                    msg,
+                    trace_id,
+                    request_id,
+                    "generation_failed",
+                    "Failed to encode response",
                 )
             finally:
                 if uses_per_request_cfg:
@@ -238,18 +276,48 @@ class ImageNatsAdapter(NatsAdapterBase):
                         pass
 
     async def _reply_error(
-        self, msg: Any, request_id: str, error: str, error_detail: str | None = None
+        self,
+        msg: Any,
+        trace_id: str,
+        request_id: str,
+        error: str,
+        error_detail: str | None = None,
     ) -> None:
-        """Send an error reply following ADR-046 contract."""
-        reply = {
-            "contract_version": "1",
-            "request_id": request_id,
-            "ok": False,
-            "error": error,
-        }
-        if error_detail:
-            reply["error_detail"] = error_detail
-        await self.reply(msg, json.dumps(reply).encode())
+        """Send an error reply per the v0.4.x ImageResponse contract.
+
+        Populates both the legacy free-text ``error: str`` field (for back-compat
+        with consumers that read it directly) and the structured ``worker_error:
+        WorkerError`` field (for v0.4.x consumers that route on canonical codes
+        + retryability).
+        """
+        worker_err = _make_worker_error(error, error_detail)
+        # ImageResponse.request_id is min_length=1; some failure paths reach here
+        # before request_id is known (e.g. malformed envelope). Use
+        # model_construct to skip validation in that single edge case — mirrors
+        # the voiceCLI _err_tts pattern.
+        safe_trace = trace_id or "unknown"
+        now = datetime.now(timezone.utc)
+        if request_id:
+            resp = ImageResponse(
+                contract_version="1",
+                trace_id=safe_trace,
+                issued_at=now,
+                request_id=request_id,
+                ok=False,
+                error=error,
+                worker_error=worker_err,
+            )
+        else:
+            resp = ImageResponse.model_construct(
+                contract_version="1",
+                trace_id=safe_trace,
+                issued_at=now,
+                request_id="",
+                ok=False,
+                error=error,
+                worker_error=worker_err,
+            )
+        await self.reply(msg, resp.model_dump_json(exclude_none=True).encode())
 
     def heartbeat_payload(self) -> dict:
         """Extend base heartbeat per lyra.image contract (see roxabi_contracts.image.models.Heartbeat)."""

--- a/src/imagecli/nats/adapter.py
+++ b/src/imagecli/nats/adapter.py
@@ -46,6 +46,8 @@ class ImageNatsAdapter(NatsAdapterBase):
             heartbeat_subject=HEARTBEAT_SUBJECT,
             heartbeat_interval=heartbeat_interval,
             drain_timeout=drain_timeout,
+            inbox_prefix="_inbox.imagecli-image",
+            wait_ready=False,  # worker semantics — see NatsAdapterBase docstring
         )
         self.default_engine = default_engine
         self.max_concurrent = max_concurrent

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -128,7 +128,7 @@ class TestImageNatsAdapter:
         reply = msg.last_reply()
         assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "prompt" in reply.get("error_detail", "")
+        assert "prompt" in ((reply.get("worker_error") or {}).get("detail") or "")
 
     # ------------------------------------------------------------------
     # Case 2: missing engine
@@ -149,7 +149,7 @@ class TestImageNatsAdapter:
         reply = msg.last_reply()
         assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "engine" in reply.get("error_detail", "")
+        assert "engine" in ((reply.get("worker_error") or {}).get("detail") or "")
 
     # ------------------------------------------------------------------
     # Case 3: unknown engine
@@ -305,9 +305,9 @@ class TestImageNatsAdapter:
         assert reply["error"] in ("invalid_request", "missing_required_field")
         assert reply["error"] != "generation_failed"
         assert (
-            "loras" in reply.get("error_detail", "").lower()
-            or "mixed" in reply.get("error_detail", "").lower()
-            or "singular" in reply.get("error_detail", "").lower()
+            "loras" in ((reply.get("worker_error") or {}).get("detail") or "").lower()
+            or "mixed" in ((reply.get("worker_error") or {}).get("detail") or "").lower()
+            or "singular" in ((reply.get("worker_error") or {}).get("detail") or "").lower()
         )
 
     @pytest.mark.xfail(reason="Adapter needs generation logic in handle() - ADR-046")
@@ -359,7 +359,7 @@ class TestImageNatsAdapter:
         reply = msg.last_reply()
         assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "request_id" in reply.get("error_detail", "")
+        assert "request_id" in ((reply.get("worker_error") or {}).get("detail") or "")
 
     def test_adapter_rejects_request_id_with_dots(self) -> None:
         _require_imports()
@@ -385,7 +385,7 @@ class TestImageNatsAdapter:
         reply = msg.last_reply()
         assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "format" in reply.get("error_detail", "")
+        assert "format" in ((reply.get("worker_error") or {}).get("detail") or "")
 
     def test_adapter_accepts_allowed_formats(self) -> None:
         """`png`, `jpeg`, `webp` are the contract-allowed formats."""

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -101,6 +101,34 @@ def _make_adapter(**kwargs):  # type: ignore[return]
     return adapter
 
 
+def _assert_worker_error(
+    reply: dict,
+    *,
+    code: str,
+    retryable: bool,
+    detail_contains: str | None = None,
+) -> None:
+    """Assert the reply carries a structured WorkerError with the expected shape.
+
+    The legacy ``or {}`` fallback (used in tests prior to the WorkerError
+    migration) passes vacuously when ``worker_error`` is absent; this helper
+    requires the field to exist before drilling into ``code``/``retryable``/
+    ``detail``.
+    """
+    assert reply["ok"] is False, f"expected ok=False, got {reply!r}"
+    we = reply.get("worker_error")
+    assert we is not None, f"worker_error missing from reply: {reply!r}"
+    assert we.get("code") == code, f"expected code={code!r}, got {we.get('code')!r}"
+    assert we.get("retryable") is retryable, (
+        f"expected retryable={retryable}, got {we.get('retryable')!r}"
+    )
+    if detail_contains is not None:
+        detail = we.get("detail") or ""
+        assert detail_contains in detail, (
+            f"expected detail containing {detail_contains!r}, got {detail!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -126,9 +154,10 @@ class TestImageNatsAdapter:
 
         # Assert
         reply = msg.last_reply()
-        assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "prompt" in ((reply.get("worker_error") or {}).get("detail") or "")
+        _assert_worker_error(
+            reply, code="worker.validation", retryable=False, detail_contains="prompt"
+        )
 
     # ------------------------------------------------------------------
     # Case 2: missing engine
@@ -147,9 +176,10 @@ class TestImageNatsAdapter:
 
         # Assert
         reply = msg.last_reply()
-        assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "engine" in ((reply.get("worker_error") or {}).get("detail") or "")
+        _assert_worker_error(
+            reply, code="worker.validation", retryable=False, detail_contains="engine"
+        )
 
     # ------------------------------------------------------------------
     # Case 3: unknown engine
@@ -298,16 +328,15 @@ class TestImageNatsAdapter:
             asyncio.run(adapter.handle(msg, payload))
 
         reply = msg.last_reply()
-        assert reply["ok"] is False
         # Must surface as a validation error — not as generation_failed,
         # which would indicate the mixed-form payload slipped past
         # _validate_request and into the generation loop.
         assert reply["error"] in ("invalid_request", "missing_required_field")
         assert reply["error"] != "generation_failed"
-        assert (
-            "loras" in ((reply.get("worker_error") or {}).get("detail") or "").lower()
-            or "mixed" in ((reply.get("worker_error") or {}).get("detail") or "").lower()
-            or "singular" in ((reply.get("worker_error") or {}).get("detail") or "").lower()
+        _assert_worker_error(reply, code="worker.validation", retryable=False)
+        detail = ((reply.get("worker_error") or {}).get("detail") or "").lower()
+        assert "loras" in detail or "mixed" in detail or "singular" in detail, (
+            f"expected detail to mention loras/mixed/singular, got {detail!r}"
         )
 
     @pytest.mark.xfail(reason="Adapter needs generation logic in handle() - ADR-046")
@@ -357,9 +386,10 @@ class TestImageNatsAdapter:
         asyncio.run(adapter.handle(msg, payload))
 
         reply = msg.last_reply()
-        assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "request_id" in ((reply.get("worker_error") or {}).get("detail") or "")
+        _assert_worker_error(
+            reply, code="worker.validation", retryable=False, detail_contains="request_id"
+        )
 
     def test_adapter_rejects_request_id_with_dots(self) -> None:
         _require_imports()
@@ -383,9 +413,56 @@ class TestImageNatsAdapter:
         asyncio.run(adapter.handle(msg, payload))
 
         reply = msg.last_reply()
-        assert reply["ok"] is False
         assert reply["error"] == "missing_required_field"
-        assert "format" in ((reply.get("worker_error") or {}).get("detail") or "")
+        _assert_worker_error(
+            reply, code="worker.validation", retryable=False, detail_contains="format"
+        )
+
+    # ------------------------------------------------------------------
+    # trace_id propagation + fallback
+    # ------------------------------------------------------------------
+    def test_adapter_forwards_explicit_trace_id(self) -> None:
+        """Inbound trace_id distinct from request_id is preserved on the reply."""
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        # Force an error path (missing prompt) to capture the reply envelope.
+        payload = _valid_payload()
+        payload["trace_id"] = "trace-abc-123"
+        del payload["prompt"]
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["trace_id"] == "trace-abc-123"
+        assert reply["request_id"] == "req-001"
+
+    def test_adapter_trace_id_falls_back_to_unknown(self) -> None:
+        """When trace_id AND request_id are absent/empty, reply trace_id is 'unknown'.
+
+        Exercises the ``model_construct`` branch in ``_reply_error`` — the only
+        path reachable when request_id is empty (ImageResponse.request_id is
+        min_length=1, so the validated constructor would refuse it).
+        """
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        # _validate_request rejects empty request_id (REQUEST_ID_PATTERN), which
+        # routes through _reply_error before request_id is replaced — but the
+        # adapter's trace_id derivation runs first, so trace_id falls back to
+        # "unknown" (payload has neither trace_id nor a usable request_id).
+        payload = _valid_payload(request_id="")
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["trace_id"] == "unknown"
+        # The model_construct branch leaves request_id="" — the reply still
+        # serializes (validation skipped) and carries the structured error.
+        assert reply["ok"] is False
+        we = reply.get("worker_error")
+        assert we is not None
+        assert we["code"] == "worker.validation"
 
     def test_adapter_accepts_allowed_formats(self) -> None:
         """`png`, `jpeg`, `webp` are the contract-allowed formats."""

--- a/tests/nats/test_integration.py
+++ b/tests/nats/test_integration.py
@@ -189,9 +189,12 @@ async def test_adapter_handles_missing_prompt(adapter, mock_nc):
 
     # Assert: error response
     response = msg.last_reply()
-    assert response["ok"] is False
     assert response["error"] == "missing_required_field"
-    assert "prompt" in ((response.get("worker_error") or {}).get("detail") or "")
+    we = response.get("worker_error")
+    assert we is not None
+    assert we["code"] == "worker.validation"
+    assert we["retryable"] is False
+    assert "prompt" in (we.get("detail") or "")
     assert response["request_id"] == "test-req-missing-prompt"
 
 
@@ -213,9 +216,12 @@ async def test_adapter_handles_missing_engine(adapter, mock_nc):
 
     # Assert: error response
     response = msg.last_reply()
-    assert response["ok"] is False
     assert response["error"] == "missing_required_field"
-    assert "engine" in ((response.get("worker_error") or {}).get("detail") or "")
+    we = response.get("worker_error")
+    assert we is not None
+    assert we["code"] == "worker.validation"
+    assert we["retryable"] is False
+    assert "engine" in (we.get("detail") or "")
 
 
 @pytest.mark.asyncio

--- a/tests/nats/test_integration.py
+++ b/tests/nats/test_integration.py
@@ -191,7 +191,7 @@ async def test_adapter_handles_missing_prompt(adapter, mock_nc):
     response = msg.last_reply()
     assert response["ok"] is False
     assert response["error"] == "missing_required_field"
-    assert "prompt" in response.get("error_detail", "")
+    assert "prompt" in ((response.get("worker_error") or {}).get("detail") or "")
     assert response["request_id"] == "test-req-missing-prompt"
 
 
@@ -215,7 +215,7 @@ async def test_adapter_handles_missing_engine(adapter, mock_nc):
     response = msg.last_reply()
     assert response["ok"] is False
     assert response["error"] == "missing_required_field"
-    assert "engine" in response.get("error_detail", "")
+    assert "engine" in ((response.get("worker_error") or {}).get("detail") or "")
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ requires-dist = [
     { name = "peft", specifier = ">=0.18.1" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "protobuf", specifier = ">=5.0" },
-    { name = "roxabi-nats", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&tag=roxabi-nats%2Fv0.1.0" },
+    { name = "roxabi-nats", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&tag=roxabi-nats%2Fv0.4.1" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "torch", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu130" },
@@ -1642,12 +1642,21 @@ wheels = [
 ]
 
 [[package]]
+name = "roxabi-contracts"
+version = "0.4.0"
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&tag=roxabi-nats%2Fv0.4.1#7a21ce8e1199147c083e5f65b0ed35cfddf6e892" }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[[package]]
 name = "roxabi-nats"
-version = "0.1.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&tag=roxabi-nats%2Fv0.1.0#4e6ec1b6369a35b3f712e577c554eac510ad8238" }
+version = "0.4.1"
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&tag=roxabi-nats%2Fv0.4.1#7a21ce8e1199147c083e5f65b0ed35cfddf6e892" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },
+    { name = "roxabi-contracts" },
 ]
 
 [[package]]
@@ -1943,9 +1952,9 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T15:04:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T15:04:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp312-cp312-win_amd64.whl", upload-time = "2026-03-23T15:04:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:252f237d417fac3ba59b1635815c1f035a8241f2af038f2c076ed430932d89f1", upload-time = "2026-04-27T20:01:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:96911323dcfcd42028c7e8edde7bdf25bb187753234e8775f0f3f112e86a22db", upload-time = "2026-04-27T20:02:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:ef8beae16d781c3244ef28dc7bee6d8871c26bbde65d5bf66e902cb61972c4ab", upload-time = "2026-04-27T20:03:28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `roxabi-nats` from `v0.1.0` → `v0.4.1` (pulls `roxabi-contracts==0.4.0` transitively, no explicit pin needed).
- Adopt the `wait_ready=False` worker opt-out introduced in lyra#1285 — `ImageNatsAdapter` is a worker (RPC responder for `lyra.image.generate.request`) and doesn't carry the `$JS.API.>` ACL grants needed by the JetStream KV readiness probe.
- Add `inbox_prefix="_inbox.imagecli-image"` to match the per-identity inbox naming used by sibling adapters (`llmCLI`, `voiceCLI`).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#84](https://github.com/Roxabi/imageCLI/issues/84): Bump roxabi-nats v0.1.0 → v0.4.1 + adopt wait_ready=False worker opt-out | OPEN |
| Frame | [artifacts/frames/84-bump-roxabi-nats-v041-frame.mdx](artifacts/frames/84-bump-roxabi-nats-v041-frame.mdx) | Approved |
| Spec | [artifacts/specs/84-bump-roxabi-nats-v041-spec.mdx](artifacts/specs/84-bump-roxabi-nats-v041-spec.mdx) | Approved |
| Plan | [artifacts/plans/84-bump-roxabi-nats-v041-plan.mdx](artifacts/plans/84-bump-roxabi-nats-v041-plan.mdx) | Approved (F-lite, 6 micro-tasks) |
| Implementation | 1 commit on `feat/84-bump-roxabi-nats-v041` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (255 passed, 5 xfailed, 2 xpassed) | Passed |

## Test Plan
- [x] `uv run pytest tests/nats/test_adapter.py` → 11 passed, 1 xfailed
- [x] `uv run pytest tests/nats/` → 13 passed, 5 xfailed, 2 xpassed
- [x] `uv run pytest` (full suite) → 255 passed, 5 xfailed, 2 xpassed
- [x] `uv run ruff check .` → clean
- [x] `uv run pyright` → 0 errors
- [x] `python -c "import inspect; from roxabi_nats import NatsAdapterBase; assert 'wait_ready' in inspect.signature(NatsAdapterBase.__init__).parameters"` → OK
- [ ] Manual smoke: `imagecli serve` startup logs show **no `$JS.API.>` ACL denial warnings** (verify when M₁ hub is reachable; documented here in lieu of CI since CI has no live NATS hub)

## Reference Implementations

Sibling repos already adopted this pattern on their `staging` tracks:
- `llmCLI/src/llmcli/nats/llm_adapter.py:59` — `inbox_prefix="_inbox.llmcli-llm"`
- `voiceCLI/src/voicecli/nats/tts_adapter.py:78` — `inbox_prefix="_inbox.voice-tts"`
- `voiceCLI/src/voicecli/nats/stt_adapter.py:75` — `inbox_prefix="_inbox.voice-stt"`

## Notes
- Pre-existing `ruff format` drift in `src/imagecli/engine/base.py` is on `origin/staging` and unrelated to this PR — left untouched.

Closes #84

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`