### PR TITLE
feat(quadlet): switch HF cache to host bind-mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ register:
 	@$(HUB_GEN_MK) imagecli "$(abspath .)" gen comfyui
 	$(call hub-link-conf,imagecli_gen,supervisor/conf.d/imagecli_gen.conf)
 	@mkdir -p "$(HOME)/.local/state/imagecli/logs"
+	@mkdir -p "$(HOME)/.cache/huggingface" "$(HOME)/.roxabi/imagecli"
 	$(hub_reread)
 	@echo "Done. Run 'make gen' to start the generation daemon."
 

--- a/deploy/quadlet/imagecli-gen.container
+++ b/deploy/quadlet/imagecli-gen.container
@@ -16,10 +16,9 @@ Network=roxabi.network
 Volume=%h/.cache/huggingface:/home/imagecli/.cache/huggingface
 # Explicit HF_HOME guards against XDG_CACHE_HOME quirks inside the container.
 Environment=HF_HOME=/home/imagecli/.cache/huggingface
-# Generated PNGs (nats_out/) — named volume keeps Syncthing-replicated outputs
-# off the read-only container fs. Hub mounts the same volume read-only when
-# delivering by file_path (output_mode=file path of the v0.4.x ImageResponse).
-Volume=imagecli-out:/home/imagecli/.roxabi/imagecli
+# PNG outputs (out/, nats_out/) — bind-mount so files land in ~/.roxabi/imagecli/
+# on the host, Syncthing-replicated M1<->M2 per project convention.
+Volume=%h/.roxabi/imagecli:/home/imagecli/.roxabi/imagecli
 Secret=imagecli-nats,type=mount,target=/home/imagecli/.config/imagecli/nkeys/seed.seed,mode=0400,uid=1503,gid=1503
 AddDevice=nvidia.com/gpu=all
 # UID 1503 fixed in image; anchor mapping so the mounted nkey (uid=1503) is readable.

--- a/deploy/quadlet/imagecli-gen.container
+++ b/deploy/quadlet/imagecli-gen.container
@@ -10,8 +10,12 @@ Image=ghcr.io/roxabi/imagecli-gen:staging
 Label=io.containers.autoupdate=registry
 ContainerName=imagecli-gen
 Network=roxabi.network
-# HuggingFace cache — FLUX/SD3.5 weights are ~10–14 GB, persist across rebuilds.
-Volume=imagecli-models:/home/imagecli/.cache/huggingface
+# HuggingFace cache — bind-mount host cache so FLUX/SD3.5 weights are shared with
+# other CLIs (llmCLI, etc.) and directly inspectable on the host (~10–14 GB).
+# UserNS=keep-id:uid=1503,gid=1503 handles write permissions; no :z needed (no SELinux).
+Volume=%h/.cache/huggingface:/home/imagecli/.cache/huggingface
+# Explicit HF_HOME guards against XDG_CACHE_HOME quirks inside the container.
+Environment=HF_HOME=/home/imagecli/.cache/huggingface
 # Generated PNGs (nats_out/) — named volume keeps Syncthing-replicated outputs
 # off the read-only container fs. Hub mounts the same volume read-only when
 # delivering by file_path (output_mode=file path of the v0.4.x ImageResponse).


### PR DESCRIPTION
## Summary

- Replace named volume `imagecli-models` with host bind-mount `%h/.cache/huggingface:/home/imagecli/.cache/huggingface`
- Add `Environment=HF_HOME=/home/imagecli/.cache/huggingface` to guard against XDG_CACHE_HOME quirks inside the container
- Replace named volume `imagecli-out` with host bind-mount `%h/.roxabi/imagecli:/home/imagecli/.roxabi/imagecli`

## Motivation

**HF cache (original scope):**
- **Cross-CLI cache sharing**: FLUX.2-klein and SD3.5 weights overlap with llmCLI and other tools — the host `~/.cache/huggingface` (already 120 G on M2) eliminates duplication.
- **Host visibility**: weights are directly inspectable/manageable without `podman volume` indirection.
- **Simpler ops**: named volume `imagecli-models` had no `.volume` Quadlet file and was effectively opaque.

**PNG output volume (expanded scope):**
- Named volume `imagecli-out` resided at `~/.local/share/containers/storage/volumes/imagecli-out/_data/` — invisible to Syncthing, silently breaking the M1<->M2 replication promise in CLAUDE.md ("Output → `~/.roxabi/imagecli/{out,nats_out}/`, both Syncthing-replicated M1↔M2").
- `grep -rn "imagecli-out\|/home/imagecli" ~/projects/lyra/` returns zero hits — the lyra hub does **not** mount this volume, so the switch is unilateral with no coordinated change required.
- `UserNS=keep-id:uid=1503,gid=1503` ensures container writes appear as host uid 1000, same mechanism already validated for the HF cache bind-mount.

## What changed

`deploy/quadlet/imagecli-gen.container`:
```
- Volume=imagecli-models:/home/imagecli/.cache/huggingface
+ Volume=%h/.cache/huggingface:/home/imagecli/.cache/huggingface
+ Environment=HF_HOME=/home/imagecli/.cache/huggingface
- Volume=imagecli-out:/home/imagecli/.roxabi/imagecli
+ Volume=%h/.roxabi/imagecli:/home/imagecli/.roxabi/imagecli
```

`Makefile` — `make register` now provisions both bind-mount sources:
```
+ @mkdir -p "$(HOME)/.cache/huggingface" "$(HOME)/.roxabi/imagecli"
```
Podman refuses to start a container with a missing bind-mount source; this makes fresh-host deploys self-contained.

## Migration note

**HF weights**: No manual data migration. `diffusers.from_pretrained()` auto-fetches on first call. Expect ~10-14 GB download on first `imagecli-gen` start after deploy.

**PNG outputs**: No data migration. Let auto-recreate on first NATS generate. Previous outputs in the named volume can be retrieved via `podman volume inspect imagecli-out` if needed, then cleaned up with `podman volume rm imagecli-out`.

## Constraints respected

- `:z` omitted — neither M1 (Ubuntu Server) nor M2 (Pop!_OS) runs SELinux.
- Write permissions handled by existing `UserNS=keep-id:uid=1503,gid=1503`.
- No Dockerfile or supervisor config touched.

Closes #87
