### PR TITLE
fix(nats): #1382 canonicalize image-worker nkeys path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Typecheck
         run: uv run pyright
       - name: Shellcheck
-        run: shellcheck scripts/*.sh
+        run: shellcheck scripts/*.sh deploy/install.sh
       - name: Check lyra.* literals outside designated adapter
         run: bash scripts/check-lyra-literals.sh
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Typecheck
         run: uv run pyright
       - name: Shellcheck
-        run: shellcheck scripts/*.sh deploy/install.sh
+        run: shellcheck scripts/*.sh deploy/*.sh
       - name: Check lyra.* literals outside designated adapter
         run: bash scripts/check-lyra-literals.sh
       - name: Test

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -67,25 +67,25 @@ run mkdir -p \
     "${DATA_DIR}/weights" \
     "${DATA_DIR}/env" \
     "$(dirname "${SEED_PATH}")"
+run mkdir -p -m 700 "$(dirname "${SEED_PATH}")"
+run chmod 700 "$(dirname "${SEED_PATH}")"
 ok "Data dirs: ${DATA_DIR}/"
-info "Canonical nkeys path: ${SEED_PATH}"
+info "Canonical nkeys path: ${SEED_PATH} (see docs/QUADLET-DEPLOYMENT.md for lyra scp workflow)"
 
 # ── secrets ───────────────────────────────────────────────────────────────────
 info "Checking secret: ${SECRET_NAME}..."
 if podman secret inspect "${SECRET_NAME}" &>/dev/null; then
     ok "Secret ${SECRET_NAME} already exists"
+    [[ -f "${SEED_PATH}" ]] || echo "  warn  ${SEED_PATH} not found — secret may be stale; see docs/QUADLET-DEPLOYMENT.md rotation steps" >&2
 elif $DRY_RUN; then
-    echo "[dry-run] Would prompt to create secret: ${SECRET_NAME}"
+    echo "[dry-run] Would create secret from ${SEED_PATH}: ${SECRET_NAME}"
 else
-    echo "Secret '${SECRET_NAME}' not found."
-    echo "Options:"
-    echo "  1. Paste NKey seed (nk... prefix):"
-    echo "     echo 'SUANKEY...' | podman secret create ${SECRET_NAME} -"
-    echo "  2. Load from file:"
-    echo "     podman secret create ${SECRET_NAME} /path/to/seed.nk"
-    echo ""
-    echo "Create the secret then re-run this script."
-    exit 1
+    [[ -f "${SEED_PATH}" ]] || {
+        echo "error: seed file missing at ${SEED_PATH}" >&2
+        exit 1
+    }
+    podman secret create "${SECRET_NAME}" "${SEED_PATH}"
+    ok "Secret ${SECRET_NAME} created from ${SEED_PATH}"
 fi
 
 # ── env file ──────────────────────────────────────────────────────────────────

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -31,6 +31,10 @@ FORCE=false
 # Canonical nkeys path (aligns with lyra acl-matrix.json target_path for image-worker,
 # Roxabi/lyra#1381). Override via IMAGECLI_SEED_PATH env var if needed.
 SEED_PATH="${IMAGECLI_SEED_PATH:-${HOME}/.roxabi/imagecli/nkeys/image-worker.seed}"
+[[ "${SEED_PATH}" = /* ]] || {
+    echo "error: IMAGECLI_SEED_PATH must be an absolute path (got: ${SEED_PATH})" >&2
+    exit 1
+}
 
 # ── arg parsing ───────────────────────────────────────────────────────────────
 for arg in "$@"; do

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -28,6 +28,10 @@ DRY_RUN=false
 SECRETS_ONLY=false
 FORCE=false
 
+# Canonical nkeys path (aligns with lyra acl-matrix.json target_path for image-worker,
+# Roxabi/lyra#1381). Override via IMAGECLI_SEED_PATH env var if needed.
+SEED_PATH="${IMAGECLI_SEED_PATH:-${HOME}/.roxabi/imagecli/nkeys/image-worker.seed}"
+
 # ── arg parsing ───────────────────────────────────────────────────────────────
 for arg in "$@"; do
     case "$arg" in
@@ -57,8 +61,10 @@ run mkdir -p \
     "${DATA_DIR}/out" \
     "${DATA_DIR}/nats_out" \
     "${DATA_DIR}/weights" \
-    "${DATA_DIR}/env"
+    "${DATA_DIR}/env" \
+    "$(dirname "${SEED_PATH}")"
 ok "Data dirs: ${DATA_DIR}/"
+info "Canonical nkeys path: ${SEED_PATH}"
 
 # ── secrets ───────────────────────────────────────────────────────────────────
 info "Checking secret: ${SECRET_NAME}..."

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -33,12 +33,16 @@ Lyra's `acl-matrix.json` (Roxabi/lyra#1381) scp's the regenerated NKey seed for 
 **Operator workflow after `lyra-acl genkeys --regenerate`:**
 
 1. Lyra fires the external scp manifest — seed lands at `~/.roxabi/imagecli/nkeys/image-worker.seed` on `roxabitower`
-2. Recreate the Podman secret from the new seed:
+2. **Secure the seed** (mandatory — scp defaults to 644):
+   ```bash
+   chmod 400 ~/.roxabi/imagecli/nkeys/image-worker.seed
+   ```
+3. Recreate the Podman secret from the new seed:
    ```bash
    podman secret rm imagecli-nats-gen
    podman secret create imagecli-nats-gen ~/.roxabi/imagecli/nkeys/image-worker.seed
    ```
-3. Restart the service:
+4. Restart the service:
    ```bash
    systemctl --user restart imagecli-gen.service
    ```

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -20,6 +20,31 @@ bash deploy/install.sh
 
 Flags: `--dry-run` | `--secrets-only` | `--force`
 
+## Canonical nkeys path
+
+Lyra's `acl-matrix.json` (Roxabi/lyra#1381) scp's the regenerated NKey seed for `image-worker` to:
+
+```
+~/.roxabi/imagecli/nkeys/image-worker.seed
+```
+
+`deploy/install.sh` creates `~/.roxabi/imagecli/nkeys/` via `mkdir -p` and prints the resolved path at install time. Override with `IMAGECLI_SEED_PATH=/custom/path` if needed.
+
+**Operator workflow after `lyra-acl genkeys --regenerate`:**
+
+1. Lyra fires the external scp manifest — seed lands at `~/.roxabi/imagecli/nkeys/image-worker.seed` on `roxabitower`
+2. Recreate the Podman secret from the new seed:
+   ```bash
+   podman secret rm imagecli-nats-gen
+   podman secret create imagecli-nats-gen ~/.roxabi/imagecli/nkeys/image-worker.seed
+   ```
+3. Restart the service:
+   ```bash
+   systemctl --user restart imagecli-gen.service
+   ```
+
+Refs: Roxabi/lyra#1382, Roxabi/lyra#1381
+
 ## Secret Management
 
 ### Create secret (first install)


### PR DESCRIPTION
## Summary
- Derive canonical `SEED_PATH=~/.roxabi/imagecli/nkeys/image-worker.seed` in `deploy/install.sh`; override via `IMAGECLI_SEED_PATH` env var
- `mkdir -p` the nkeys dir in the data-dirs block (idempotent); print resolved path at install time
- Document the path in `docs/QUADLET-DEPLOYMENT.md` with operator workflow for post-regenerate seed rotation

## Why
Until this lands, lyra's scp manifest for `image-worker` (introduced in Roxabi/lyra#1381) points to a path imageCLI doesn't read. Fan-out succeeds, worker silently misses new seed.

## Test plan
- [x] Bash syntax: `bash -n deploy/install.sh`
- [ ] Manual: `bash deploy/install.sh --dry-run` prints `~/.roxabi/imagecli/nkeys/` mkdir
- [ ] Manual: `install.sh` creates `~/.roxabi/imagecli/nkeys/` if missing
- [ ] Manual: `IMAGECLI_SEED_PATH=/tmp/custom.seed bash deploy/install.sh --dry-run` uses override path

Refs: Roxabi/lyra#1382, Roxabi/lyra#1381