### PR TITLE
fix(tests): patch correct callsite in preflight failure test

### DIFF
--- a/tests/nats/test_integration.py
+++ b/tests/nats/test_integration.py
@@ -194,7 +194,7 @@ async def test_adapter_handles_preflight_failure(adapter, mock_engine, mock_nc):
     msg = MockNatsMessage(b"test")
 
     with (
-        patch("imagecli.engine.get_engine", return_value=mock_engine),
+        patch("imagecli.model_registry.model_registry.get", return_value=mock_engine),
         patch(
             "imagecli.engine.preflight_check", side_effect=InsufficientResourcesError("low VRAM")
         ),


### PR DESCRIPTION
Fixes pre-existing test failure in .

## Root cause
The test patched , but the no-LoRA path in  routes through  instead. This caused the test to hit the real registry (which fails to load torch/diffusers in test env) and map to  instead of .

## Fix
Patch  instead.

## Verification
- 38/38 nats tests pass
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)