### PR TITLE
fix(ci): enforce merge-commit only + block dependabot semver-major auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,11 @@
 # Auto-merge PRs that have been reviewed and passed all required checks.
-# Adds the PR to GitHub's merge queue (squash) once the "reviewed" label is present.
+# Adds the PR to GitHub's merge queue (merge commit) once the "reviewed" label is present.
 # GitHub natively waits for all required status checks before merging.
+#
+# Project convention: merge commits only (¬squash) — see ~/projects/CLAUDE.md
+# "Release Convention". Squash merges flatten the per-commit history that
+# staging→main promotions rely on. Dependabot semver-major bumps are never
+# auto-merged — manual validation required.
 #
 # Also closes linked issues after merge, because GITHUB_TOKEN-initiated
 # auto-merges don't trigger GitHub's native "Closes #X" issue closure.
@@ -31,8 +36,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Enable auto-merge (squash)
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+      - name: Block dependabot semver-major bumps
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ from\ v?([0-9]+)[^\ ]*\ to\ v?([0-9]+) ]] && [ "${BASH_REMATCH[1]}" != "${BASH_REMATCH[2]}" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "Auto-merge refusé : bump **semver-major**. Validation manuelle requise (e2e / boot de l'artefact), puis merge à la main."
+            echo "::error::semver-major dependency bump — auto-merge refused"
+            exit 1
+          fi
+
+      - name: Enable auto-merge (merge commit)
+        run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Revue 2026-06-10 — fix transversal (même PR sur plugins #275, boilerplate, forge, imageCLI, production) :

- `--auto --squash` → `--auto --merge` : la convention merge-commit-only était violée par le workflow lui-même (cas concret : plugins #273 squashé sur staging)
- Guard dependabot : refuse l'auto-merge (job rouge + commentaire) si bump **semver-major** — regex titre validée sur 6 formats (npm, pip, docker, actions, v-prefix, groupes minor-and-patch)

Côté serveur déjà appliqué : rulesets PR_Main → `["merge"]` + settings repo squash/rebase off (après merge de ce PR pour ce repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)