### PR TITLE
feat(contracts): echo job_id on response models + contracts-bump caller (Roxabi/roxabi-factory#1840)

### DIFF
--- a/.github/workflows/contracts-bump-caller.yml
+++ b/.github/workflows/contracts-bump-caller.yml
@@ -1,0 +1,16 @@
+# .github/workflows/contracts-bump-caller.yml  (in Roxabi/imageCLI)
+name: Bump contracts lock
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Every Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: ${{ github.repository }}
+      packages: "roxabi-contracts roxabi-nats roxabi-blobs"
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/src/imagecli/nats/adapter.py
+++ b/src/imagecli/nats/adapter.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from roxabi_blobs.protocol import BlobStore
 from roxabi_contracts.blob_ref import BlobRef as WireBlobRef
+from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.errors import WorkerError
 from roxabi_contracts.image import SUBJECTS, ImageResponse
 from roxabi_nats import NatsAdapterBase
@@ -93,13 +94,16 @@ class ImageNatsAdapter(NatsAdapterBase):
         # to request_id (then "unknown") so error paths can still produce a
         # valid ImageResponse when the client omits it.
         trace_id = payload.get("trace_id") or request_id or "unknown"
+        job_id = payload.get("job_id")
 
         # Acquire semaphore for concurrency control
         async with self._sem:
             # Validate required fields and bounds
             valid, error = _validate_request(payload)
             if not valid:
-                await self._reply_error(msg, trace_id, request_id, "missing_required_field", error)
+                await self._reply_error(
+                    msg, trace_id, request_id, "missing_required_field", error, job_id=job_id
+                )
                 return
 
             engine_name = payload["engine"]
@@ -110,14 +114,21 @@ class ImageNatsAdapter(NatsAdapterBase):
                 from imagecli.engine import get_engine, preflight_check, list_engines
             except ImportError as e:
                 await self._reply_error(
-                    msg, trace_id, request_id, "engine_load_failed", f"Import error: {e}"
+                    msg,
+                    trace_id,
+                    request_id,
+                    "engine_load_failed",
+                    f"Import error: {e}",
+                    job_id=job_id,
                 )
                 return
 
             # Validate engine name against registry
             engine_names = {e["name"] for e in list_engines()}
             if engine_name not in engine_names:
-                await self._reply_error(msg, trace_id, request_id, "unknown_engine", engine_name)
+                await self._reply_error(
+                    msg, trace_id, request_id, "unknown_engine", engine_name, job_id=job_id
+                )
                 return
 
             # Get or create engine instance.
@@ -142,7 +153,9 @@ class ImageNatsAdapter(NatsAdapterBase):
                 self._engine_loaded = engine_name
             except Exception as e:
                 error_code, error_detail = _map_exception_to_error(e)
-                await self._reply_error(msg, trace_id, request_id, error_code, error_detail)
+                await self._reply_error(
+                    msg, trace_id, request_id, error_code, error_detail, job_id=job_id
+                )
                 return
 
             # Preflight check (VRAM/RAM validation)
@@ -150,7 +163,9 @@ class ImageNatsAdapter(NatsAdapterBase):
                 preflight_check(engine)
             except Exception as e:
                 error_code, error_detail = _map_exception_to_error(e)
-                await self._reply_error(msg, trace_id, request_id, error_code, error_detail)
+                await self._reply_error(
+                    msg, trace_id, request_id, error_code, error_detail, job_id=job_id
+                )
                 return
 
             # Extract generation params with defaults
@@ -203,7 +218,9 @@ class ImageNatsAdapter(NatsAdapterBase):
                             tmp_path.unlink()
                     except OSError:
                         pass
-                await self._reply_error(msg, trace_id, request_id, error_code, error_detail)
+                await self._reply_error(
+                    msg, trace_id, request_id, error_code, error_detail, job_id=job_id
+                )
                 return
 
             # PUT → build response → reply. Wrapped in a single try (#97 N2): any
@@ -228,7 +245,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                     )
 
                 resp = ImageResponse(
-                    contract_version="1",
+                    contract_version=CONTRACT_VERSION,
                     trace_id=trace_id,
                     issued_at=datetime.now(timezone.utc),
                     request_id=request_id,
@@ -239,6 +256,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                     height=height,
                     engine=engine_name,
                     seed_used=seed if seed is not None else 0,
+                    **({"job_id": job_id} if job_id is not None else {}),
                 )
                 await self.reply(msg, resp.model_dump_json(exclude_none=True).encode())
 
@@ -253,6 +271,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                     request_id,
                     "delivery_failed",
                     sanitized,
+                    job_id=job_id,
                 )
             finally:
                 if uses_per_request_cfg:
@@ -274,6 +293,7 @@ class ImageNatsAdapter(NatsAdapterBase):
         request_id: str,
         error: str,
         error_detail: str | None = None,
+        job_id: str | None = None,
     ) -> None:
         """Send an error reply per the v0.4.x ImageResponse contract.
 
@@ -291,23 +311,25 @@ class ImageNatsAdapter(NatsAdapterBase):
         now = datetime.now(timezone.utc)
         if request_id:
             resp = ImageResponse(
-                contract_version="1",
+                contract_version=CONTRACT_VERSION,
                 trace_id=safe_trace,
                 issued_at=now,
                 request_id=request_id,
                 ok=False,
                 error=error,
                 worker_error=worker_err,
+                **({"job_id": job_id} if job_id is not None else {}),
             )
         else:
             resp = ImageResponse.model_construct(
-                contract_version="1",
+                contract_version=CONTRACT_VERSION,
                 trace_id=safe_trace,
                 issued_at=now,
                 request_id="",
                 ok=False,
                 error=error,
                 worker_error=worker_err,
+                **({"job_id": job_id} if job_id is not None else {}),
             )
         await self.reply(msg, resp.model_dump_json(exclude_none=True).encode())
 

--- a/src/imagecli/nats/adapter.py
+++ b/src/imagecli/nats/adapter.py
@@ -244,6 +244,9 @@ class ImageNatsAdapter(NatsAdapterBase):
                         "a live ingest must yield a real store_key"
                     )
 
+                # hoisted dict[str, Any] — inline **({...} if ...) makes pyright
+                # type the spread as dict[str, str] and reject remaining kwargs
+                job_kw: dict[str, Any] = {"job_id": job_id} if job_id is not None else {}
                 resp = ImageResponse(
                     contract_version=CONTRACT_VERSION,
                     trace_id=trace_id,
@@ -256,7 +259,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                     height=height,
                     engine=engine_name,
                     seed_used=seed if seed is not None else 0,
-                    **({"job_id": job_id} if job_id is not None else {}),
+                    **job_kw,
                 )
                 await self.reply(msg, resp.model_dump_json(exclude_none=True).encode())
 
@@ -309,6 +312,8 @@ class ImageNatsAdapter(NatsAdapterBase):
         # the voiceCLI _err_tts pattern.
         safe_trace = trace_id or "unknown"
         now = datetime.now(timezone.utc)
+        # hoisted dict[str, Any] — see success-path note on inline-spread pyright limits
+        job_kw: dict[str, Any] = {"job_id": job_id} if job_id is not None else {}
         if request_id:
             resp = ImageResponse(
                 contract_version=CONTRACT_VERSION,
@@ -318,7 +323,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                 ok=False,
                 error=error,
                 worker_error=worker_err,
-                **({"job_id": job_id} if job_id is not None else {}),
+                **job_kw,
             )
         else:
             resp = ImageResponse.model_construct(
@@ -329,7 +334,7 @@ class ImageNatsAdapter(NatsAdapterBase):
                 ok=False,
                 error=error,
                 worker_error=worker_err,
-                **({"job_id": job_id} if job_id is not None else {}),
+                **job_kw,
             )
         await self.reply(msg, resp.model_dump_json(exclude_none=True).encode())
 

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -473,3 +473,106 @@ class TestImageNatsAdapter:
     # delivery-failure coverage lives in `test_integration.py` via
     # `test_handle_blobstore_put_failure_returns_delivery_failed` and
     # `test_handle_reply_failure_after_put_returns_delivery_failed`.
+
+    # ------------------------------------------------------------------
+    # job_id echo — #1840
+    # ------------------------------------------------------------------
+    def test_job_id_echoed_on_error_path(self) -> None:
+        """job_id from the request is echoed back on error replies (#1840)."""
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload()
+        payload["job_id"] = "job-echo-err-001"
+        del payload["prompt"]  # triggers missing_required_field on the error path
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply.get("job_id") == "job-echo-err-001", (
+            f"expected job_id='job-echo-err-001' echoed on error reply, got {reply.get('job_id')!r}"
+        )
+
+    def test_job_id_echoed_on_success_path(self) -> None:
+        """job_id from the request is echoed back on the success reply (#1840).
+
+        We patch ImageResponse to capture constructor kwargs (including job_id)
+        without running full Pydantic validation — which would fail because our
+        blob_ref is a MagicMock, not a real BlobRef. The captured kwargs are the
+        ground-truth evidence that the adapter passed job_id through correctly.
+        """
+        _require_imports()
+        import json
+        import os
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_blob_store = MagicMock()
+        mock_blob_store.put = AsyncMock(return_value=MagicMock())
+
+        adapter = _make_adapter(max_concurrent=1, blob_store=mock_blob_store)
+        msg = MockMsg()
+        payload = _valid_payload()
+        payload["job_id"] = "job-echo-ok-002"
+
+        mock_engine = MagicMock()
+        mock_engine.cleanup = MagicMock()
+        mock_engine.clear_cache = MagicMock()
+
+        fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp.write(fake_image_bytes)
+            fake_path = Path(tmp.name)
+
+        mock_engine.generate = MagicMock(return_value=fake_path)
+
+        # Intercept ImageResponse() — capture kwargs, return serializable mock.
+        captured_kwargs: dict = {}
+
+        def _fake_image_response(*args, **kwargs):  # type: ignore[return]
+            captured_kwargs.update(kwargs)
+            mock_resp = MagicMock()
+            mock_resp.model_dump_json.return_value = json.dumps(
+                {
+                    "ok": True,
+                    "job_id": kwargs.get("job_id", ""),
+                    "request_id": kwargs.get("request_id", ""),
+                }
+            )
+            return mock_resp
+
+        # WireBlobRef: from_store_ref returns mock with truthy store_key.
+        fake_wire_ref = MagicMock()
+        fake_wire_ref.store_key = "blobstore://test/image.png"
+
+        try:
+            with (
+                patch("imagecli.engine.get_engine", return_value=mock_engine),
+                patch("imagecli.engine.list_engines", return_value=[{"name": "flux2-klein"}]),
+                patch("imagecli.engine.preflight_check"),
+                patch("imagecli.nats.adapter.WireBlobRef") as mock_wire_cls,
+                patch("imagecli.nats.adapter.ImageResponse", side_effect=_fake_image_response),
+                patch("imagecli.model_registry.model_registry") as mock_registry,
+            ):
+                mock_wire_cls.from_store_ref.return_value = fake_wire_ref
+                mock_registry.get.return_value = mock_engine
+                mock_registry.loaded_engines.return_value = []
+                asyncio.run(adapter.handle(msg, payload))
+        finally:
+            try:
+                os.unlink(fake_path)
+            except OSError:
+                pass
+
+        # Primary assertion: adapter passed job_id= to ImageResponse constructor.
+        assert captured_kwargs.get("job_id") == "job-echo-ok-002", (
+            f"expected job_id='job-echo-ok-002' passed to ImageResponse, "
+            f"got {captured_kwargs.get('job_id')!r} (full kwargs: {captured_kwargs})"
+        )
+        # Secondary: the serialized reply reflects job_id on the wire.
+        reply = msg.last_reply()
+        assert reply.get("job_id") == "job-echo-ok-002", (
+            f"expected job_id='job-echo-ok-002' echoed on success reply, got {reply.get('job_id')!r}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1652,7 +1652,7 @@ wheels = [
 [[package]]
 name = "roxabi-blobs"
 version = "0.1.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#08ed8d16a75a54dfd870522e7fb23944e7b22a7d" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "httpx" },
@@ -1661,8 +1661,8 @@ dependencies = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.7.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#08ed8d16a75a54dfd870522e7fb23944e7b22a7d" }
+version = "0.9.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1670,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#08ed8d16a75a54dfd870522e7fb23944e7b22a7d" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },


### PR DESCRIPTION
## Summary

- Echo `job_id` from inbound payload back on all `ImageResponse` replies (success + error paths)
- Import `CONTRACT_VERSION` from `roxabi_contracts.envelope` instead of hardcoding
- Add `contracts-bump-caller.yml` workflow (weekly cron + `workflow_dispatch`) calling the reusable `contracts-bump.yml` from factory staging
- Bump `uv.lock`: `roxabi-contracts` v0.7.0→v0.9.0, `roxabi-nats`, `roxabi-blobs` updated to factory staging HEAD

Closes #1840

## Implementation notes

- `job_id` extraction: `payload.get('job_id')` in `handle()`, propagated to all 7 `_reply_error()` callsites and to success-path `ImageResponse`
- Used `**({"job_id": job_id} if job_id is not None else {})` spread pattern to avoid triggering `_validate_job_id` field validator (v0.9.0, `mode="before"`) with `None` — when absent, `default_factory=new_job_id` mints a fresh UUID
- `_reply_error()` signature gains `job_id: str | None = None` parameter

## Test plan

- [x] `test_job_id_echoed_on_error_path` — missing `prompt` triggers error path; asserts `job_id` echoed
- [x] `test_job_id_echoed_on_success_path` — patches `ImageResponse` to capture kwargs; asserts `job_id` passed and echoed in reply
- [x] All existing adapter tests pass (15 tests)
- [x] Full test suite: 304 passed, 6 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)