### PR TITLE
ci: replace shared org PAT with roxabi-ci GitHub App tokens

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -33,6 +33,13 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reviewed')
     timeout-minutes: 5
     steps:
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -53,7 +60,7 @@ jobs:
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
   update-behind-prs:
@@ -62,6 +69,13 @@ jobs:
     if: github.event_name == 'push'
     timeout-minutes: 5
     steps:
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -81,7 +95,7 @@ jobs:
               --method PUT -f expected_head_sha="$SHA" || true
           done
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
 
   close-linked-issues:
     name: Close linked issues


### PR DESCRIPTION
## Summary
- Replace the long-lived org-wide `secrets.PAT` with ephemeral installation tokens minted by the `roxabi-ci` GitHub App (`actions/create-github-app-token` v3.2.0, SHA-pinned). Org-wide migration wave — pilot validated on Roxabi/roxabi-plugins#284.

## Test Plan
- [ ] CI green (workflow YAML only)
- [ ] Auto-merge enabled by `roxabi-ci[bot]` after the `reviewed` label (validates the mint in this repo)

---
Generated with [Claude Code](https://claude.com/claude-code)