### PR TITLE
chore(ci): correct setup-uv version comment (v7 -> v8.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - name: Lockfile drift
         run: uv lock --check
       - name: Install dependencies


### PR DESCRIPTION
D-30: the pinned setup-uv SHA is v8.0.0 but the comment said v7 — a silent v7->v8 major jump masked by a wrong label. Comment-only fix.