### PR TITLE
fix(deploy): rename stale lyra-nats refs to factory-nats in imagecli-gen quadlet

### DIFF
--- a/deploy/quadlet/imagecli-gen.container
+++ b/deploy/quadlet/imagecli-gen.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=imageCLI generation NATS worker
-Wants=lyra-nats.service
-After=lyra-nats.service
+Wants=factory-nats.service
+After=factory-nats.service
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
@@ -28,8 +28,8 @@ Secret=imagecli-blobstore-token,type=mount,target=imagecli-blobstore-token,uid=1
 AddDevice=nvidia.com/gpu=all
 # UID 1503 fixed in image; anchor mapping so the mounted nkey (uid=1503) is readable.
 UserNS=keep-id:uid=1503,gid=1503
-# Big-bang NATS consolidation — connect to shared lyra-nats on roxabi.network.
-Environment=NATS_URL=nats://lyra-nats:4222
+# Connect to factory-nats on roxabi.network (factory.* wire, #1670 lockstep).
+Environment=NATS_URL=nats://factory-nats:4222
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/imagecli-nats-gen.seed
 Environment=IMAGECLI_BLOBSTORE_TOKEN_PATH=/run/secrets/imagecli-blobstore-token
 Environment=IMAGECLI_BLOBSTORE_URL=http://roxabituwer:8449


### PR DESCRIPTION
## What
`imagecli-gen.container` still referenced the pre-rename NATS unit `lyra-nats` in four places — `Wants=`/`After=` deps, the `NATS_URL` container-DNS host, and the inline comment. The lyra→factory rename (epic #1671, closed 2026-06-08) renamed `lyra-nats.service` → `factory-nats.service`, so on revive this dormant worker would gate on a non-existent unit and dial an unresolvable host.

## Fix
Faithful rename → aligns with the canonical `voiceCLI` satellite pattern (`Wants/After=factory-nats.service`, `NATS_URL=nats://factory-nats:4222`).

## Scope note (out of this PR)
- **Live M₂** copy (`~/.config/containers/systemd/imagecli-gen.container`) is diverged (active `.container` + a `.container.disabled` variant using LAN IP `192.168.1.16` + a `.d` drop-in). Worker is **dormant** → cleanest is to let `deploy.sh` re-render from this fixed SSoT on revival, not hand-patch the diverged unit.
- **Cross-host topology** (pre-existing, not introduced here): `factory-nats` is container-DNS = won't resolve M₂→M₁; revival should use tailnet `roxabituwer:4222` per the NATS-hub-tailnet convention. Tracked separately.

Refs: `docs/ops-consistency-audit-2026-06-15` **D-2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)