### PR TITLE
fix(quadlet): add HealthStartPeriod grace to imagecli-gen GPU worker (D-14)

### DIFF
--- a/deploy/quadlet/imagecli-gen.container
+++ b/deploy/quadlet/imagecli-gen.container
@@ -40,6 +40,8 @@ Volume=%h/.roxabi/imagecli/weights:/home/imagecli/.roxabi/imagecli/weights:ro,Z
 Environment=IMAGECLI_ENGINE=flux2-klein
 HealthCmd=pgrep -f "imagecli nats-serve"
 HealthInterval=30s
+# Grace for diffusion model cold-load (FLUX/SD3.5 weights + CUDA init) before health failures count.
+HealthStartPeriod=120s
 NoNewPrivileges=true
 DropCapability=all
 


### PR DESCRIPTION
## What
Add `HealthStartPeriod=120s` to `imagecli-gen`.

## Why
Diffusion model cold-load (FLUX/SD3.5 weights + CUDA init) had no startup grace, unlike the `llmcli-*` units. Purely additive — `pgrep` probe, `HealthInterval`, `DropCapability=all`, `NoNewPrivileges` unchanged. Cannot affect a running container.

## Scope
Ops-consistency audit **D-14**. ReadOnly (D-6) + memory caps (D-7) for this GPU unit are intentionally **not** here — they need a host validation run (no fleet precedent for ReadOnly on a CUDA/torch unit; memcap values RSS-sensitive).

Ref: `docs/ops-consistency-audit-2026-06-15.md`