### PR TITLE
fix(deploy): fix trailing-quote HealthCmd bug + add quoting gate

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -58,3 +58,10 @@ quality_gates:
   import_layers:
     enabled: true
     stage: pre-push
+  healthcmd_quoting:
+    enabled: true
+    script: tools/check_healthcmd_quoting.sh
+    stage: pre-push
+    description: >
+      Detect Quadlet HealthCmd values ending in a double-quote (Podman ≤5.7.0
+      strips trailing quotes, causing false-unhealthy status).

--- a/deploy/quadlet/imagecli-gen.container
+++ b/deploy/quadlet/imagecli-gen.container
@@ -38,7 +38,9 @@ Environment=IMAGECLI_BLOBSTORE_URL=http://roxabituwer:8449
 Volume=%h/.roxabi/imagecli/weights:/home/imagecli/.roxabi/imagecli/weights:ro,Z
 # Engine override without rebuilding the image (see Dockerfile.gen CMD).
 Environment=IMAGECLI_ENGINE=flux2-klein
-HealthCmd=pgrep -f "imagecli nats-serve"
+# Podman Quadlet ≤5.7.0 strips a trailing double-quote from HealthCmd → unterminated shell
+# string → false-unhealthy even when the service is running fine. End with a non-quote token.
+HealthCmd=pgrep -f "imagecli nats-serve" || exit 1
 HealthInterval=30s
 NoNewPrivileges=true
 DropCapability=all

--- a/tools/check_healthcmd_quoting.sh
+++ b/tools/check_healthcmd_quoting.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check_healthcmd_quoting.sh — scan Quadlet unit files for the trailing-double-quote
+# HealthCmd bug (Podman ≤5.7.0 strips a trailing " from HealthCmd values, producing an
+# unterminated shell string and false-"unhealthy" status while the service runs fine).
+#
+# Exit codes (dev-core contract):
+#   0 — all HealthCmd values clean
+#   1 — one or more violations found (print file:line for each)
+#   2 — script error (bad environment, missing required tools, etc.)
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "ERROR: not inside a git repository" >&2
+    exit 2
+}
+
+# Scan deploy/quadlet/*.container and *.container.disabled
+SEARCH_DIR="$REPO_ROOT/deploy/quadlet"
+
+if [ ! -d "$SEARCH_DIR" ]; then
+    echo "WARN: $SEARCH_DIR not found — no Quadlet units to scan" >&2
+    exit 0
+fi
+
+FAIL=0
+
+# Find all .container and .container.disabled files
+while IFS= read -r -d '' unit_file; do
+    rel="${unit_file#"$REPO_ROOT/"}"
+    lineno=0
+    while IFS= read -r line; do
+        lineno=$((lineno + 1))
+        # Match HealthCmd= lines
+        if [[ "$line" =~ ^[[:space:]]*HealthCmd= ]]; then
+            # Strip trailing whitespace to get the last non-whitespace character
+            trimmed="${line%"${line##*[! ]}"}"
+            last_char="${trimmed: -1}"
+            if [ "$last_char" = '"' ]; then
+                echo "FAIL: $rel:$lineno — HealthCmd ends with '\"' (Podman ≤5.7.0 strips trailing quote → false-unhealthy)"
+                echo "      $line"
+                FAIL=1
+            fi
+        fi
+    done < "$unit_file"
+done < <(find "$SEARCH_DIR" \( -name "*.container" -o -name "*.container.disabled" \) -print0)
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "OK: no trailing-quote HealthCmd found in $SEARCH_DIR"
+fi
+
+exit $FAIL


### PR DESCRIPTION
## Root cause

Podman Quadlet ≤5.7.0 strips a **trailing double-quote** from `HealthCmd` values during unit file parsing. The original line:

```
HealthCmd=pgrep -f "imagecli nats-serve"
```

is parsed as `pgrep -f "imagecli nats-serve` — an unterminated shell string. Podman evaluates it, the shell bails on the syntax error, and the container is marked **unhealthy indefinitely** even while `nats-serve` runs correctly.

## Changes

### Change 1 — Fix `deploy/quadlet/imagecli-gen.container`

```diff
-HealthCmd=pgrep -f "imagecli nats-serve"
+# Podman Quadlet ≤5.7.0 strips a trailing double-quote from HealthCmd → unterminated shell
+# string → false-unhealthy even when the service is running fine. End with a non-quote token.
+HealthCmd=pgrep -f "imagecli nats-serve" || exit 1
```

The `|| exit 1` suffix ensures the last character is `1` (not `"`), the inner quotes are preserved, and semantics are identical: `pgrep` exits 0 on match, non-zero otherwise — `exit 1` is redundant but harmless on mismatch and essential as the bug workaround.

### Change 2 — Add `tools/check_healthcmd_quoting.sh`

Scans `deploy/quadlet/*.container` and `*.container.disabled` for any `HealthCmd=` line whose last non-whitespace character is `"`. Prints `file:line` for each violation and exits 1. Wired into `.claude/stack.yml` `quality_gates.healthcmd_quoting` (stage: pre-push).

**Exit-code contract (dev-core standard):** 0 = clean, 1 = violations found, 2 = script error.

## Test results

| Test | Command | Result |
|---|---|---|
| Positive (fixed tree) | `bash tools/check_healthcmd_quoting.sh` | `OK: no trailing-quote HealthCmd found` — exit 0 |
| Negative (injected bad unit) | Added `HealthCmd=pgrep -f "imagecli nats-serve"` to temp file | `FAIL: deploy/quadlet/test_bad.container:2 — HealthCmd ends with '"'` — exit 1 |

## Notes

- The gen unit in the repo is `imagecli-gen.container` (not `.disabled`) — the `.disabled` suffix only exists in the deployed copy on M₂ (`~/.config/containers/systemd/`), which is **not touched by this PR** (repo files only).
- No other `*.container` or `*.container.disabled` files in `deploy/quadlet/` at this time; the gate future-proofs for any additions.