### PR TITLE
ci(quadlet-lint): add quadlet-lint gate (converge with factory/voiceCLI)

### DIFF
--- a/.github/workflows/quadlet-lint.yml
+++ b/.github/workflows/quadlet-lint.yml
@@ -1,0 +1,109 @@
+name: Quadlet Lint
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main, staging]
+    paths:
+      - "deploy/quadlet/**"
+  workflow_dispatch: {}
+
+concurrency:
+  group: quadlet-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quadlet-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Podman 5.x
+        # ubuntu-latest (24.04) ships Podman 4.9.3. Pin Podman 5.x (from Ubuntu 25.04
+        # plucky universe) for parity with the factory / voiceCLI / llmCLI quadlet-lint
+        # gates: identical generator version, the /usr/libexec/podman/quadlet path the
+        # dryrun relies on, and forward-compat for any 5.0+-only directive added later.
+        #
+        # We add the plucky apt source with lowest priority (pin = 100) so only the
+        # explicitly named packages are upgraded; the rest of the system stays on noble.
+        run: |
+          set -euo pipefail
+          # Add Ubuntu 25.04 (plucky) as a supplementary source at low priority.
+          echo "deb https://archive.ubuntu.com/ubuntu plucky main universe" \
+            | sudo tee /etc/apt/sources.list.d/plucky.list
+          # Pin plucky to priority 100 (below the default 500 for noble) so apt
+          # never auto-selects plucky packages for unrelated deps.
+          printf 'Package: *\nPin: release n=plucky\nPin-Priority: 100\n' \
+            | sudo tee /etc/apt/preferences.d/plucky-pin
+          sudo apt-get update -qq
+          # Install Podman and its direct runtime deps from plucky with pinned
+          # versions for reproducibility (captured from plucky archive 2026-05-07).
+          # Update intentionally when upgrading: apt-cache policy podman conmon crun
+          sudo apt-get install -y --no-install-recommends \
+            -t plucky \
+            'podman=5.4.1+ds1-1' \
+            'conmon=2.1.12-4' \
+            'crun=1.20-1syncable1'
+          # Assert the 3 pinned packages are installed at exactly the expected versions.
+          # Positive-pin assert (ported from factory #1331 / #1350) — the older awk
+          # apt-cache policy leak detector misfired on runner image 20260518.149+,
+          # false-positiving on transitive plucky deps and silently killing the gate.
+          for pkg_ver in 'podman=5.4.1+ds1-1' 'conmon=2.1.12-4' 'crun=1.20-1syncable1'; do
+            pkg="${pkg_ver%%=*}"
+            want="${pkg_ver#*=}"
+            got=$(dpkg-query -W -f='${Version}' "$pkg")
+            [[ "$got" == "$want" ]] || { echo "::error::$pkg expected $want, got $got"; exit 1; }
+          done
+          # Verify we have Podman ≥ 5.x before proceeding.
+          PODMAN_VERSION=$(podman --version | awk '{print $3}')
+          echo "Installed Podman ${PODMAN_VERSION}"
+          MAJOR=$(echo "${PODMAN_VERSION}" | cut -d. -f1)
+          if [[ "${MAJOR}" -lt 5 ]]; then
+            echo "::error::Expected Podman ≥ 5; got ${PODMAN_VERSION}"
+            exit 1
+          fi
+
+      - name: Quadlet dryrun — parse errors
+        run: |
+          set -euo pipefail
+          # roxabi.network is owned by roxabi-factory (its defining repo); imageCLI
+          # units only attach to it (the host creates the real bridge at deploy). Provide
+          # a throwaway stub in a separate search dir so the generator can resolve the
+          # `Network=roxabi.network` reference during lint, without vendoring factory's
+          # SSoT into this repo. (Resolution is by unit filename, not NetworkName.)
+          STUB_DIR="$(mktemp -d)"
+          printf '[Network]\nDriver=bridge\n' > "${STUB_DIR}/roxabi.network"
+          export QUADLET_UNIT_DIRS="${GITHUB_WORKSPACE}/deploy/quadlet:${STUB_DIR}"
+          # Emit generator logs to stderr; non-zero exit on parse error.
+          /usr/libexec/podman/quadlet --dryrun --user 2>&1
+          echo "quadlet --dryrun passed"
+
+      - name: Quadlet inline-comment check
+        # Quadlet does NOT strip trailing # comments from option values.
+        # A line such as:  Volume=foo:bar:z  # comment
+        # causes Podman to receive the literal comment as a mount-option string.
+        # This step rejects any non-comment line that contains a trailing # comment
+        # in a Quadlet unit file (issue #1083 — incident 2026-05-06).
+        run: |
+          set -euo pipefail
+          QUADLET_DIR="deploy/quadlet"
+          PATTERN='^\s*[^#;].*[[:space:]]#'
+          BAD_FILES=()
+          while IFS= read -r -d '' f; do
+            if grep -Pn "${PATTERN}" "$f"; then
+              BAD_FILES+=("$f")
+            fi
+          done < <(find "${QUADLET_DIR}" \
+              -maxdepth 1 \
+              \( -name "*.container" -o -name "*.volume" -o -name "*.network" \) \
+              -print0)
+          if [[ ${#BAD_FILES[@]} -gt 0 ]]; then
+            echo ""
+            echo "::error::Inline # comments found in Quadlet value lines in: ${BAD_FILES[*]}"
+            echo "Quadlet does not strip trailing comments — use a dedicated comment line instead."
+            exit 1
+          fi
+          echo "No inline comments on value lines — OK"


### PR DESCRIPTION
## Close the quadlet-lint gate gap (imageCLI)

imageCLI had **no `quadlet-lint` workflow`** — unlike factory & voiceCLI. `deploy/quadlet/imagecli-gen.container` edits merged with no CI Quadlet dryrun.

Ports the **fixed** gate from voiceCLI staging:
- positive version-pin assertion (not the rotted awk leak detector — D-32)
- `roxabi.network` throwaway stub — imageCLI attaches to factory's network (D-33)
- inline-comment check (#1083)

`imagecli-gen` uses no 5.0+-only directive, so the Podman 5.x pin is kept purely for **gate-parity** (identical generator + `/usr/libexec/podman/quadlet` path across the devcore CLI repos) — comment says so honestly.

**Validated locally:** `quadlet --dryrun` parses `imagecli-gen` (exit 0), inline-comment clean. I'll `workflow_dispatch` it post-merge to confirm green.

Closes D-18-adjacent convergence gap (`ops-consistency-audit-2026-06-15`).