### PR TITLE
feat(nats): migrate imageCLI adapter to roxabi-satellite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,4 @@
 @.claude/stack.yml
-@~/.claude/shared/global-patterns.md
 
 # imageCLI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ explicit = true
 torch = [{ index = "pytorch-cu130" }]
 torchvision = [{ index = "pytorch-cu130" }]
 diffusers = { git = "https://github.com/huggingface/diffusers.git", tag = "v0.37.1" }
-roxabi-satellite = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-satellite", branch = "feat/roxabi-satellite" }
+roxabi-satellite = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-satellite", branch = "staging" }
 
 [tool.uv]
 override-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,7 @@ dependencies = [
     "einops>=0.8.2",
     "facexlib>=0.3.0",
     "peft>=0.18.1",
-    "roxabi-nats",
-    "roxabi-contracts",
-    "roxabi-blobs",
+    "roxabi-satellite",
     "httpx>=0.27",
 ]
 
@@ -49,9 +47,7 @@ explicit = true
 torch = [{ index = "pytorch-cu130" }]
 torchvision = [{ index = "pytorch-cu130" }]
 diffusers = { git = "https://github.com/huggingface/diffusers.git", tag = "v0.37.1" }
-roxabi-nats = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-nats", branch = "staging" }
-roxabi-contracts = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-contracts", branch = "staging" }
-roxabi-blobs = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-blobs", branch = "staging" }
+roxabi-satellite = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-satellite", branch = "feat/roxabi-satellite" }
 
 [tool.uv]
 override-dependencies = [

--- a/src/imagecli/commands/serve.py
+++ b/src/imagecli/commands/serve.py
@@ -25,25 +25,10 @@ def serve(
 
 
 def _init_blob_store() -> BlobStore:
-    """Instantiate HttpBlobStore from config (ADR-067, #97). Fail-fast on missing token.
+    """Return the shared HttpBlobStore singleton (ADR-067, #97)."""
+    from imagecli.nats.blobs import get_blobstore
 
-    Sources for the token (highest precedence first):
-      1. file at ``IMAGECLI_BLOBSTORE_TOKEN_PATH`` (Quadlet mount-type secret)
-      2. ``imagecli.toml [blobstore].token``
-      3. ``IMAGECLI_BLOBSTORE_TOKEN`` env var
-    Endpoint defaults to ``http://roxabituwer:8449`` (M₁ lyra-blobstore).
-    """
-    from imagecli.config import load_blobstore_config
-    from roxabi_blobs.http_store import HttpBlobStore
-
-    cfg = load_blobstore_config()
-    if cfg["token"] is None:
-        raise RuntimeError(
-            "blobstore token not configured — mount the Quadlet secret "
-            "'imagecli-blobstore-token' (with IMAGECLI_BLOBSTORE_TOKEN_PATH set to its mount), "
-            "or set imagecli.toml [blobstore].token, or IMAGECLI_BLOBSTORE_TOKEN env var."
-        )
-    return HttpBlobStore(base_url=cfg["endpoint"], token=cfg["token"])
+    return get_blobstore()
 
 
 async def _probe_blobstore(endpoint: str) -> None:

--- a/src/imagecli/nats/adapter.py
+++ b/src/imagecli/nats/adapter.py
@@ -12,9 +12,9 @@ from typing import Any
 from roxabi_blobs.protocol import BlobStore
 from roxabi_contracts.blob_ref import BlobRef as WireBlobRef
 from roxabi_contracts.envelope import CONTRACT_VERSION
-from roxabi_contracts.errors import WorkerError
 from roxabi_contracts.image import SUBJECTS, ImageResponse
 from roxabi_nats import NatsAdapterBase
+from roxabi_satellite.image.replies import build_image_error_reply
 
 from imagecli.nats.validators import (
     _map_exception_to_error,
@@ -26,31 +26,6 @@ from imagecli.nats.validators import (
 log = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
-
-# Map legacy free-text error codes (kept for backward compat in `error: str`)
-# to structured WorkerError fields. `default_retryable` follows KNOWN_CODES
-# in roxabi_contracts.errors. Unmapped codes fall back to worker.internal.
-#
-# `delivery_failed` covers an OSError moving the generated file into
-# nats_out/ — generation succeeded but persistence failed. There is no
-# `image.delivery_failed` in KNOWN_CODES yet (request upstream), so we use
-# `worker.internal` per its docstring: "not covered by a more specific code."
-# Hub routing on `retryable=True` works identically to `worker.crash`.
-_WORKER_ERROR_MAP: dict[str, tuple[str, bool]] = {
-    "missing_required_field": ("worker.validation", False),
-    "unknown_engine": ("worker.validation", False),
-    "engine_load_failed": ("image.engine_unavailable", True),
-    "insufficient_resources": ("worker.capacity", True),
-    "generation_failed": ("worker.crash", True),
-    "delivery_failed": ("worker.internal", True),
-}
-
-
-def _make_worker_error(code: str, detail: str | None = None) -> WorkerError:
-    """Build a structured WorkerError from a legacy free-text error code."""
-    canonical, retryable = _WORKER_ERROR_MAP.get(code, ("worker.internal", True))
-    return WorkerError(code=canonical, message=code, retryable=retryable, detail=detail)
-
 
 class ImageNatsAdapter(NatsAdapterBase):
     """NATS adapter for image generation requests from Lyra hub.
@@ -70,7 +45,7 @@ class ImageNatsAdapter(NatsAdapterBase):
     ) -> None:
         super().__init__(
             subject=SUBJECTS.image_request,
-            queue_group="IMAGE_WORKERS",
+            queue_group=SUBJECTS.image_workers,
             envelope_name="image",
             schema_version=SCHEMA_VERSION,
             heartbeat_subject=SUBJECTS.image_heartbeat,
@@ -305,38 +280,16 @@ class ImageNatsAdapter(NatsAdapterBase):
         WorkerError`` field (for v0.4.x consumers that route on canonical codes
         + retryability).
         """
-        worker_err = _make_worker_error(error, error_detail)
-        # ImageResponse.request_id is min_length=1; some failure paths reach here
-        # before request_id is known (e.g. malformed envelope). Use
-        # model_construct to skip validation in that single edge case — mirrors
-        # the voiceCLI _err_tts pattern.
-        safe_trace = trace_id or "unknown"
-        now = datetime.now(timezone.utc)
-        # hoisted dict[str, Any] — see success-path note on inline-spread pyright limits
-        job_kw: dict[str, Any] = {"job_id": job_id} if job_id is not None else {}
-        if request_id:
-            resp = ImageResponse(
-                contract_version=CONTRACT_VERSION,
-                trace_id=safe_trace,
-                issued_at=now,
+        await self.reply(
+            msg,
+            build_image_error_reply(
+                trace_id=trace_id,
                 request_id=request_id,
-                ok=False,
                 error=error,
-                worker_error=worker_err,
-                **job_kw,
-            )
-        else:
-            resp = ImageResponse.model_construct(
-                contract_version=CONTRACT_VERSION,
-                trace_id=safe_trace,
-                issued_at=now,
-                request_id="",
-                ok=False,
-                error=error,
-                worker_error=worker_err,
-                **job_kw,
-            )
-        await self.reply(msg, resp.model_dump_json(exclude_none=True).encode())
+                error_detail=error_detail,
+                job_id=job_id,
+            ),
+        )
 
     def heartbeat_payload(self) -> dict:
         """Extend base heartbeat per factory.image contract (see roxabi_contracts.image.models.Heartbeat)."""

--- a/src/imagecli/nats/blobs.py
+++ b/src/imagecli/nats/blobs.py
@@ -6,16 +6,16 @@ import threading
 
 from roxabi_blobs.http_store import HttpBlobStore
 
-_INSTANCE: HttpBlobStore | None = None
+_blobstore_instance: HttpBlobStore | None = None
 _LOCK = threading.Lock()
 
 
 def get_blobstore() -> HttpBlobStore:
     """Return process-local HttpBlobStore, creating from config on first call."""
-    global _INSTANCE
-    if _INSTANCE is None:
+    global _blobstore_instance
+    if _blobstore_instance is None:
         with _LOCK:
-            if _INSTANCE is None:
+            if _blobstore_instance is None:
                 from imagecli.config import load_blobstore_config
 
                 cfg = load_blobstore_config()
@@ -24,12 +24,14 @@ def get_blobstore() -> HttpBlobStore:
                         "blobstore token not configured — set IMAGECLI_BLOBSTORE_TOKEN_PATH, "
                         "imagecli.toml [blobstore].token, or IMAGECLI_BLOBSTORE_TOKEN"
                     )
-                _INSTANCE = HttpBlobStore(base_url=cfg["endpoint"], token=cfg["token"])
-    return _INSTANCE
+                _blobstore_instance = HttpBlobStore(
+                    base_url=cfg["endpoint"], token=cfg["token"]
+                )
+    return _blobstore_instance
 
 
 def reset_blobstore_for_tests() -> None:
     """Reset singleton between tests."""
-    global _INSTANCE
+    global _blobstore_instance
     with _LOCK:
-        _INSTANCE = None
+        _blobstore_instance = None

--- a/src/imagecli/nats/blobs.py
+++ b/src/imagecli/nats/blobs.py
@@ -1,0 +1,35 @@
+"""HttpBlobStore singleton for imageCLI NATS worker — mirrors voiceCLI pattern."""
+
+from __future__ import annotations
+
+import threading
+
+from roxabi_blobs.http_store import HttpBlobStore
+
+_INSTANCE: HttpBlobStore | None = None
+_LOCK = threading.Lock()
+
+
+def get_blobstore() -> HttpBlobStore:
+    """Return process-local HttpBlobStore, creating from config on first call."""
+    global _INSTANCE
+    if _INSTANCE is None:
+        with _LOCK:
+            if _INSTANCE is None:
+                from imagecli.config import load_blobstore_config
+
+                cfg = load_blobstore_config()
+                if cfg["token"] is None:
+                    raise RuntimeError(
+                        "blobstore token not configured — set IMAGECLI_BLOBSTORE_TOKEN_PATH, "
+                        "imagecli.toml [blobstore].token, or IMAGECLI_BLOBSTORE_TOKEN"
+                    )
+                _INSTANCE = HttpBlobStore(base_url=cfg["endpoint"], token=cfg["token"])
+    return _INSTANCE
+
+
+def reset_blobstore_for_tests() -> None:
+    """Reset singleton between tests."""
+    global _INSTANCE
+    with _LOCK:
+        _INSTANCE = None

--- a/src/imagecli/nats/validators.py
+++ b/src/imagecli/nats/validators.py
@@ -213,37 +213,7 @@ def _map_exception_to_error(exc: Exception) -> tuple[str, str]:
 
 
 def _sanitize_delivery_exception(exc: Exception) -> str:
-    """Map an httpx / BlobStore exception to a safe diagnostic string.
+    """Re-export from ``roxabi_satellite.image.delivery``."""
+    from roxabi_satellite.image.delivery import sanitize_delivery_exception
 
-    Sibling to :func:`_map_exception_to_error` — engine-side errors stay there,
-    delivery-side (HttpBlobStore) errors live here. The two stay separate
-    because their type domains are orthogonal (``httpx.*`` vs
-    ``imagecli.engine.*``).
-
-    The returned string is wire-facing (``WorkerError.detail``) AND log-facing
-    (``_probe_blobstore`` warning), so it MUST NOT carry URLs, headers, or any
-    string serialised from ``httpx.Request`` — those can embed the Bearer
-    token or query-string auth. We classify by ``isinstance`` only and never
-    interpolate ``exc`` directly.
-    """
-    # httpx is an optional transitive dep of roxabi-blobs.HttpBlobStore — lazy
-    # import so this helper stays usable even when httpx isn't installed
-    # (e.g., the legacy CLI path that never exercises the NATS adapter).
-    try:
-        import httpx
-    except ImportError:
-        return "internal delivery error"
-
-    if isinstance(exc, httpx.HTTPStatusError):
-        # Narrowed by isinstance at runtime; httpx isn't statically typed here
-        # because of the lazy import.
-        status_code = exc.response.status_code  # type: ignore[attr-defined]
-        return f"upstream HTTP {status_code}"
-    if isinstance(exc, httpx.TimeoutException):
-        return "BlobStore request timed out"
-    if isinstance(exc, httpx.ConnectError):
-        return "BlobStore connection failed"
-    if isinstance(exc, httpx.HTTPError):
-        # Generic httpx parent — covers ProtocolError, RemoteProtocolError, etc.
-        return "BlobStore transport error"
-    return "internal delivery error"
+    return sanitize_delivery_exception(exc)

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -50,6 +50,10 @@ def test_adapter_binds_subjects_from_contracts() -> None:
         f"adapter._heartbeat_subject ({adapter._heartbeat_subject!r}) must equal "
         f"SUBJECTS.image_heartbeat ({SUBJECTS.image_heartbeat!r})."
     )
+    assert adapter.queue_group == SUBJECTS.image_workers, (
+        f"adapter.queue_group ({adapter.queue_group!r}) must equal "
+        f"SUBJECTS.image_workers ({SUBJECTS.image_workers!r})."
+    )
 
 
 def _require_imports() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -555,9 +555,7 @@ dependencies = [
     { name = "peft" },
     { name = "pillow" },
     { name = "protobuf" },
-    { name = "roxabi-blobs" },
-    { name = "roxabi-contracts" },
-    { name = "roxabi-nats" },
+    { name = "roxabi-satellite" },
     { name = "sentencepiece" },
     { name = "torch" },
     { name = "torchvision" },
@@ -605,9 +603,7 @@ requires-dist = [
     { name = "peft", specifier = ">=0.18.1" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "protobuf", specifier = ">=5.0" },
-    { name = "roxabi-blobs", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging" },
-    { name = "roxabi-contracts", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
-    { name = "roxabi-nats", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
+    { name = "roxabi-satellite", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=feat%2Froxabi-satellite" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "torch", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu130" },
@@ -1652,7 +1648,7 @@ wheels = [
 [[package]]
 name = "roxabi-blobs"
 version = "0.1.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "httpx" },
@@ -1661,8 +1657,8 @@ dependencies = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.9.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
+version = "0.11.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1670,11 +1666,22 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },
     { name = "roxabi-contracts" },
+]
+
+[[package]]
+name = "roxabi-satellite"
+version = "0.1.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "roxabi-blobs" },
+    { name = "roxabi-contracts" },
+    { name = "roxabi-nats" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ requires-dist = [
     { name = "peft", specifier = ">=0.18.1" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "protobuf", specifier = ">=5.0" },
-    { name = "roxabi-satellite", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=feat%2Froxabi-satellite" },
+    { name = "roxabi-satellite", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=staging" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "torch", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu130" },
@@ -1648,7 +1648,7 @@ wheels = [
 [[package]]
 name = "roxabi-blobs"
 version = "0.1.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#340e8ad130760817ca4b42a5deeb063b9627f10b" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "httpx" },
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "roxabi-contracts"
 version = "0.11.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#340e8ad130760817ca4b42a5deeb063b9627f10b" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#340e8ad130760817ca4b42a5deeb063b9627f10b" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "roxabi-satellite"
 version = "0.1.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=feat%2Froxabi-satellite#f20fd204ecec9eab77cacd81965f4e9b3c95d95c" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=staging#340e8ad130760817ca4b42a5deeb063b9627f10b" }
 dependencies = [
     { name = "pydantic" },
     { name = "roxabi-blobs" },


### PR DESCRIPTION
## Summary

- `ImageNatsAdapter` uses `build_image_error_reply` + shared delivery sanitization
- `nats-serve` wires blobstore via `imagecli.nats.blobs` singleton
- Single dep: `roxabi-satellite` (transitive contracts/nats/blobs)

**Depends on:** [Roxabi/roxabi-factory#2024](https://github.com/Roxabi/roxabi-factory/pull/2024)

## Review

Partie **F** in [factory review plan](https://github.com/Roxabi/roxabi-factory/blob/feat/roxabi-satellite/artifacts/reviews/roxabi-satellite-review-parts.md)

**Hors scope:** scripts enishu / engine metadata — non inclus dans ce PR.

## Test Plan

- [x] `uv run pytest tests/nats` — 40 passed

---
Stack PR 3/4