### PR TITLE
docs(adr): describe imagecli-gen as Quadlet worker

### DIFF
--- a/docs/architecture/adr/046-imagecli-nats-ingress.mdx
+++ b/docs/architecture/adr/046-imagecli-nats-ingress.mdx
@@ -39,7 +39,7 @@ This ADR assumes Python 3.12 (`requires-python = ">=3.12,<3.13"`). Rationale:
 
 ### Architecture
 
-`ImageNatsAdapter` subclasses `NatsAdapterBase` from the `roxabi-nats` SDK. It runs as a standalone supervisor process (`imagecli_gen`), subscribes to `lyra.image.generate.request`, and responds to the reply-to inbox. The hub never imports imageCLI — this process does.
+`ImageNatsAdapter` subclasses `NatsAdapterBase` from the `roxabi-nats` SDK. It runs as a standalone Quadlet worker (`imagecli-gen`), subscribes to `lyra.image.generate.request`, and responds to the reply-to inbox. The hub never imports imageCLI — this process does.
 
 ```
 Lyra hub (no imageCLI import)


### PR DESCRIPTION
## Summary
- Remove legacy supervisord hub references (conf.d, hub.mk, make register, supervisorctl)
- Align service management with Quadlet + systemd --user standard

## Test Plan
- [x] Makefiles parse (`make help` / `make -n <target> status`)
- [x] No functional code paths call supervisorctl

---
Generated with Claude Code