### PR TITLE
fix(ci+deploy): contracts-bump secrets: inherit + imagecli-gen NATS URL (tailnet)

### DIFF
--- a/.github/workflows/contracts-bump-caller.yml
+++ b/.github/workflows/contracts-bump-caller.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   bump:
     uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    # Reusable workflows do NOT inherit caller secrets by default — without this the
+    # reusable workflow's actions/create-github-app-token fails ("private-key must be
+    # non-empty"), which broke this weekly cron 9/9 runs since inception (audit 2026-07-01).
+    secrets: inherit
     with:
       satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats roxabi-blobs"

--- a/deploy/quadlet/imagecli-gen.container
+++ b/deploy/quadlet/imagecli-gen.container
@@ -28,8 +28,10 @@ Secret=imagecli-blobstore-token,type=mount,target=imagecli-blobstore-token,uid=1
 AddDevice=nvidia.com/gpu=all
 # UID 1503 fixed in image; anchor mapping so the mounted nkey (uid=1503) is readable.
 UserNS=keep-id:uid=1503,gid=1503
-# Connect to factory-nats on roxabi.network (factory.* wire, #1670 lockstep).
-Environment=NATS_URL=nats://factory-nats:4222
+# Connect to factory-nats on M1 over the tailnet (imageCLI runs on M2/image-worker;
+# `factory-nats` container-DNS only resolves on M1's roxabi.network). Mirrors the
+# blobstore/OTEL endpoints below (roxabituwer:*) and llmCLI's M2 worker (#audit-2026-07-01).
+Environment=NATS_URL=nats://roxabituwer:4222
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/imagecli-nats-gen.seed
 Environment=IMAGECLI_BLOBSTORE_TOKEN_PATH=/run/secrets/imagecli-blobstore-token
 Environment=IMAGECLI_BLOBSTORE_URL=http://roxabituwer:8449


### PR DESCRIPTION
Deux fixes (audit 2026-07-01) :
1. **contracts-bump** : `secrets: inherit` — cron échoué 9/9 (caller sans secrets → create-github-app-token `private-key must be non-empty`).
2. **imagecli-gen NATS_URL** : container-DNS `factory-nats:4222` → tailnet `roxabituwer:4222` (M2 ne résout pas le DNS conteneur M1). Latent (imageCLI dormant), à valider au re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)