### PR TITLE
ci: skip full CI on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   ci:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -28,6 +30,7 @@ jobs:
         run: uv run pytest
 
   secrets:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Secret scan
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Skip full CI jobs when `pull_request.draft` is true (WIP pushes no longer burn Actions minutes).
- Listen for `ready_for_review` so undrafting re-triggers CI.
- Leave secret-scan / pr-title / context-lint unchanged; `reviewed` stays the merge gate only.

## Test plan
- [ ] Open a draft PR → CI jobs show as skipped
- [ ] Mark ready for review → CI runs
- [ ] Push to a ready PR → CI still runs
- [ ] Push to main/staging → CI unchanged
